### PR TITLE
[CX-2479] Fix issues missing secrets datafold containers

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/dfshell/templates/deployment.yaml
+++ b/charts/datafold/charts/dfshell/templates/deployment.yaml
@@ -41,6 +41,60 @@ spec:
                 name: {{ include "datafold.configmap" . }}
           env:
             {{ include "datafold.env" . | nindent 12 }}
+            - name: DATAFOLD_FRESHPAINT_FRONTEND_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_FRESHPAINT_FRONTEND_TOKEN
+            - name: DATAFOLD_FRESHPAINT_BACKEND_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_FRESHPAINT_BACKEND_TOKEN
+            - name: DATAFOLD_FRESHPAINT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_FRESHPAINT_URL
+            - name: DATAFOLD_AVO_INSPECTOR_FRONTEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_AVO_INSPECTOR_FRONTEND_API_KEY
+            - name: DATAFOLD_INSTALL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_INSTALL_PASSWORD
+            - name: DATAFOLD_DATADOG_CLIENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_DATADOG_CLIENT_TOKEN
+            - name: DATAFOLD_DATADOG_APPLICATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_DATADOG_APPLICATION_ID
+            {{- if (eq .Values.global.optional.intercom "true") }}
+            - name: DATAFOLD_INTERCOM_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_INTERCOM_APP_ID
+            {{- end }}
+            {{- if (eq .Values.global.optional.googleAuth "true") }}
+            - name: DATAFOLD_GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_GOOGLE_CLIENT_ID
+            - name: DATAFOLD_GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_GOOGLE_CLIENT_SECRET
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/datafold/charts/worker/templates/deployment.yaml
+++ b/charts/datafold/charts/worker/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
           env:
             {{ include "worker.env" . | nindent 12 }}
             {{ include "datafold.env" . | nindent 12 }}
+            - name: DATAFOLD_FRESHPAINT_BACKEND_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_FRESHPAINT_BACKEND_TOKEN
             - name: DATAFOLD_FRESHPAINT_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
Freshpaint events coudn't be sent due to missing secrets/env vars. 

## Solution
I chose to add the secrets currently added to the `server` pod to all datafold containers. 

## Why?
We can execute `./manage.py` and `ipython` commands from all datafold containers, but if we do not have all env vars from the `settings.py` available we do get inconsistent result and given that a developer probably does not expect missing env vars all the sudden if they are in a particular (identical) container, this will otherwise cause significant loss of productivity and frustration. 