### PR TITLE
fix: Set surge to same number as replica count

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: {{ .Values.replicaCount }}
       maxUnavailable: 0
   selector:
     matchLabels:

--- a/charts/datafold/charts/worker/templates/deployment.yaml
+++ b/charts/datafold/charts/worker/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: {{ .Values.replicaCount }}
       maxUnavailable: 0
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

When a worker has multiple containers, the surge should be equal to the replica count so that it starts up the same number of new workers. Otherwise it can lead to reduction in availability.