### PR TITLE
[CX-3165]: Use celery healthcheck as a better liveness probe

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker/templates/deployment.yaml
+++ b/charts/datafold/charts/worker/templates/deployment.yaml
@@ -62,9 +62,12 @@ spec:
               command:
               - /bin/bash
               - -c
-              - ps -ef | grep celeryd | grep -v grep
-            initialDelaySeconds: 10
-            periodSeconds: 60
+              - /app/bin/docker_entrypoint celery_healthcheck
+            initialDelaySeconds: 60
+            periodSeconds: 180
+            failureThreshold: 2
+            successThreshold: 1
+            timeoutSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}


### PR DESCRIPTION
Merge after most recent PR is merged due to version numbers.

## Description
The liveness probe for workers is ok when redis is guaranteed to be up all of the time, but if redis is taken down and then it comes back up, all workers go into a sleepy unconnected state that never terminates. The only way to deal with that is to restart all workers manually.

This change to the livenessprobe checks through redis if the host (pod) is connected. If it cannot see the pod connected on redis, it will fail the check.

The reason it's interval is 3 minutes is because it takes time to run the command and there are reports of these pings consuming a high amount of CPU. The command also takes time, around 10s to run or so, so we should at the most run this every 60s. 