### PR TITLE
[BOYSCOUT] Revert back to df11

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.25
+version: 0.6.26
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/clickhouse/Chart.yaml
+++ b/charts/datafold/charts/clickhouse/Chart.yaml
@@ -3,4 +3,4 @@ name: clickhouse
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0
-appVersion: "24.3.2.23-df12"
+appVersion: "24.3.2.23-df11"


### PR DESCRIPTION
revert back to df11 to avoid having to redeploy to other dedicated clouds (will fix df11 Dockerfile for clickhouse in datafold repo)

*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
