### PR TITLE
Allow more flexibility for Clickhouse chart

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.39
+version: 0.6.40
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/datafold/charts/clickhouse/templates/_helpers.tpl
@@ -191,7 +191,9 @@ ad.datadoghq.com/{{ .Chart.Name }}.checks: |
 Defines remote storage system to use
 */}}
 {{- define "clickhouse.remote_storage" -}}
-{{- if .Values.global.cloudProvider -}}
+{{- if .Values.config.remote_storage -}}
+{{ .Values.config.remote_storage }}
+{{- else if .Values.global.cloudProvider -}}
 {{-   if (eq .Values.global.cloudProvider "aws") -}}
 "s3"
 {{-   else if (eq .Values.global.cloudProvider "gcp") -}}

--- a/charts/datafold/charts/clickhouse/templates/statefulset.yaml
+++ b/charts/datafold/charts/clickhouse/templates/statefulset.yaml
@@ -62,11 +62,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "clickhouse.secrets" . }}
                   key: S3_ACCESS_KEY
+                  optional: true
             - name: S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "clickhouse.secrets" . }}
                   key: S3_SECRET_KEY
+                  optional: true
             - name: GCS_CREDENTIALS_JSON
               valueFrom:
                 secretKeyRef:

--- a/charts/datafold/charts/clickhouse/values.yaml
+++ b/charts/datafold/charts/clickhouse/values.yaml
@@ -36,6 +36,8 @@ config:
   gcs_path: "backups"
   azblob_account_name: ""
   azblob_container: ""
+  # One of: s3, gcs, azblob. Leave empty to auto-detect based on "global.cloudProvider".
+  remote_storage: ""
 
 secrets:
   access_key: "override_this"


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
- [chore: allow overwriting clickhouse remote_storage](https://github.com/datafold/helm-charts/commit/35c852140aaee7d3caa1a51ff592f9cefc5d0711)
- [chore: make clickhouse s3 creds env optional (for use with instance creds/ServiceAccount)](https://github.com/datafold/helm-charts/commit/d44dd09d7771900f4dc9717ab0bde48ee679e080) 

