### PR TITLE
fix: Add missing CLICKHOUSE_DB env var

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.43
+version: 0.6.44
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/datadog/templates/datadog_operator.yaml
+++ b/charts/datafold/charts/datadog/templates/datadog_operator.yaml
@@ -69,6 +69,8 @@ spec:
             secretKeyRef:
               name: {{ include "datafold.secrets" . }}
               key: DATAFOLD_CLICKHOUSE_USER
+        - name: CLICKHOUSE_DB
+          value: {{ .Values.global.clickhouse.database }}
         - name: DD_CONTAINER_EXCLUDE
           value: "image:gcr.io/datadoghq.* kube_namespace:.*"
         - name: DD_CONTAINER_INCLUDE


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
CLICKHOUSE_DB env var was missing from the agent, since the agent needs to have the value of this env var and not just the pod.