### PR TITLE
fix: Set default term grace period lineage to 5m

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.56
+version: 0.6.57
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/nginx/values.yaml
+++ b/charts/datafold/charts/nginx/values.yaml
@@ -35,10 +35,10 @@ securityContext:
 
 resources:
   limits:
-    memory: 100Mi
+    memory: 270Mi
   requests:
     cpu: 100m
-    memory: 100Mi
+    memory: 270Mi
 
 volumes: []
 

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -251,6 +251,7 @@ worker-singletons:
 
 worker-lineage:
   install: false
+  terminationGracePeriodSeconds: "300"
 
 worker-monitor:
   install: false


### PR DESCRIPTION
## Description

* Sets term grace period for lineage worker to 5 minutes.
* Increases memory nginx to 270M from 100M