### PR TITLE
fix: Improve resilience by deploying web pods twice

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.67
+version: 0.6.68
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/nginx/values.yaml
+++ b/charts/datafold/charts/nginx/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 2
 image:
   repository: nginx
   pullPolicy: IfNotPresent
@@ -48,4 +48,17 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - nginx
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - datafold
+        topologyKey: "kubernetes.io/hostname"

--- a/charts/datafold/charts/server/values.yaml
+++ b/charts/datafold/charts/server/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 2
 
 image:
   pullPolicy: IfNotPresent
@@ -41,10 +41,10 @@ ingress:
 
 resources:
   limits:
-    memory: 7000Mi
+    memory: 6Gi
   requests:
     cpu: 500m
-    memory: 7000Mi
+    memory: 6Gi
 
 autoscaling:
   enabled: false
@@ -60,4 +60,17 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - server
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - datafold
+        topologyKey: "kubernetes.io/hostname"

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -86,7 +86,7 @@ nginx:
   install: true
 
 config:
-  webWorkers: "4"
+  webWorkers: "3"
   workerCount: "15"
   githubServer: ""
   portalCertData: ""


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
