### PR TITLE
fix: Improve storage worker deployment

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.69
+version: 0.6.70
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/storage-worker/templates/statefulset.yaml
+++ b/charts/datafold/charts/storage-worker/templates/statefulset.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     {{- include "worker.labels" . | nindent 4 }}
 spec:
+  podManagementPolicy: "Parallel"
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.replicaCount }}
-      maxUnavailable: {{ .Values.replicaCount }}
+      maxUnavailable: 100%
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete
     whenScaled: Delete
@@ -50,6 +50,8 @@ spec:
           env:
             {{ include "worker.env" . | nindent 12 }}
             {{ include "datafold.env" . | nindent 12 }}
+            - name: DATAFOLD_CELERY_TASKS_ACK_LATE
+              value: "{{ .Values.worker.tasks_ack_late }}"
             - name: DATAFOLD_FRESHPAINT_BACKEND_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/datafold/charts/storage-worker/values.yaml
+++ b/charts/datafold/charts/storage-worker/values.yaml
@@ -14,9 +14,10 @@ command: celery_worker
 
 worker:
   queues: "localstorage"
-  tasks: 200
+  tasks: 1
   memory: 850000
-  count: 2
+  count: 1
+  tasks_ack_late: "false"
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
* Removes maxSurge on updateStrategy, which does not exist for statefulset
* Adds new env var to stop task pre-fetching
* Make it configurable