### PR TITLE
fix: Anti-affinity of heavy cpu workers with clickhouse

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.6.70
+version: 0.6.71
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -219,6 +219,22 @@ worker-catalog:
     requests:
       cpu: 1000m
       memory: 13000Mi
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - clickhouse
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - datafold
+            topologyKey: "kubernetes.io/hostname"
 
 worker-interactive:
   install: true
@@ -255,6 +271,22 @@ worker-singletons:
 worker-lineage:
   install: false
   terminationGracePeriodSeconds: "300"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - clickhouse
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - datafold
+            topologyKey: "kubernetes.io/hostname"
 
 worker-monitor:
   install: true


### PR DESCRIPTION
## Description

Clickhouse and lineage/catalog are usually heavy on cpu and on dc's, this would avoid having them on the same node, so CPU is better spread.