### PR TITLE
Fix custom resource DF manager spec version

### DIFF
--- a/charts/datafold/templates/df_app_manager.yaml
+++ b/charts/datafold/templates/df_app_manager.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "datafold.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: datafold
 spec:
-  version: "{{ .Values.global.datafoldVersion }}"
+  datafoldVersion: "{{ .Values.global.datafoldVersion }}"


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description

In dfappmanagers.crds.datafold.com [schema](https://github.com/datafold/helm-charts/blob/main/charts/datafold-crds/templates/dfappmanagers.yaml#L25), there is no such attribute called `version`, it should be `datafoldVersion`. 