### PR TITLE
fix: Stop installing temporal worker by default

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.7.9
+version: 0.7.10
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.7.10
+version: 0.7.11
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 0
 image:
   pullPolicy: IfNotPresent
   tag: ""


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
