### PR TITLE
Increase claude code max output tokens

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.10
+version: 0.10.11
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/dma/values.yaml
+++ b/charts/datafold/charts/dma/values.yaml
@@ -74,7 +74,7 @@ dma:
   anthropic_model: ""
   anthropic_small_fast_model: ""
   disable_prompt_caching: "0"
-  claude_max_output_tokens: "4096"
+  claude_max_output_tokens: "32768"
   claude_max_thinking_tokens: "1024"
 
 # ConfigMap to load environment variables from


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
Increases the default `CLAUDE_CODE_MAX_OUTPUT_TOKENS` for the DMA component from 4K to 32K, as requested in ENG-2071. This provides Claude Code with a larger output capacity.

---
Linear Issue: [ENG-2071](https://linear.app/datafold/issue/ENG-2071/increase-default-max-output-tokens-for-claude-code)

<a href="https://cursor.com/background-agent?bcId=bc-80b677bc-cd70-4819-8840-81dfa140e26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80b677bc-cd70-4819-8840-81dfa140e26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

