### PR TITLE
fix: Slow status_check probes to 10s and increase workers io pool

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.99
+version: 0.1.100
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.1.69"
+    tag: "1.1.70"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.82
+version: 0.10.83
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -143,8 +143,8 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
-            periodSeconds: 5
-            failureThreshold: 12
+            periodSeconds: 10
+            failureThreshold: 6
             timeoutSeconds: 5
           livenessProbe:
             failureThreshold: 10
@@ -171,7 +171,7 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
-            periodSeconds: 5
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
           resources:

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -237,15 +237,16 @@ worker-io:
   terminationGracePeriodSeconds: "30"
   temporal:
     taskQueues: "io"
+    maxConcurrency: "20"
     workerPoolType: "thread"
   keda:
     minReplicas: 0
   resources:
     limits:
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 500m
-      memory: 4Gi
+      memory: 6Gi
 
 worker-compute:
   install: true


### PR DESCRIPTION
## Summary

Dial back the server `/status_check` probe rate from 5s to 10s and raise the IO temporal worker's **per-pod thread count** (`TEMPORAL_MAX_CONCURRENCY`) from 5 to 35. The earlier version of this PR scaled replicas (`keda.maxReplicas`) instead — that was the wrong lever; the bottleneck is threads per pod, not pod count.

[ENG-3818](https://linear.app/datafold/issue/ENG-3818/improve-datafold-stability)

Companion PR: [datafold-operator#101](https://github.com/datafold/datafold-operator/pull/101) (submodule pointer bump; semantic-release publishes the `1.1.70` operator image this PR pre-references).

### Why

After [#321](https://github.com/datafold/helm-charts/pull/321) (ENG-3739) lowered the server's `startupProbe` and `readinessProbe` to `periodSeconds: 5`, and after [datafold#12284](https://github.com/datafold/datafold/pull/12284) added direct Postgres + ClickHouse Alembic migration-version queries to `/status_check`, the server now executes those heavy checks every 5 seconds via two concurrent probes per pod. Bumping the period to 10s halves that query rate while keeping the rollout-safety wins from #321.

Separately, `worker-io` was running with `TEMPORAL_MAX_CONCURRENCY=5` (subchart default from `charts/datafold/charts/worker-temporal/values.yaml`) → `ThreadPoolExecutor(max_workers=5)` and `Worker(max_concurrent_activities=5)` per pod (`datafold/temporal/temporal_worker.py:138,155,181`). With `keda.maxReplicas: 10` (subchart default), the in-flight IO ceiling is 50. The actual constraint is per-pod concurrency: thread-pool overhead is cheap for I/O-bound activities (mostly DB/git ops), and bumping threads is the right lever before scaling replicas.

### Changes

- `charts/datafold/charts/server/templates/deployment.yaml`
  - `startupProbe.periodSeconds`: `5 → 10`, `failureThreshold`: `12 → 6` (keeps the same ~60s startup budget)
  - `readinessProbe.periodSeconds`: `5 → 10`
  - `livenessProbe` unchanged (already at 15s)
- `charts/datafold/values.yaml`
  - `worker-io.temporal.maxConcurrency: "35"` (new field; previously inherited the worker-temporal subchart default `"5"`)
  - `keda.maxReplicas` no longer overridden in worker-io block — clusters keep the subchart-default cap of 10. The "scaledobject relationship" the ticket called out stays intact: KEDA still scales 0→10 pods based on queue depth; each pod now has 7× the thread capacity.
- Version bumps:
  - `charts/datafold/Chart.yaml`: `0.10.82 → 0.10.83` — chart-releaser cuts a new `datafold` chart release with the probe + values changes.
  - `charts/datafold-manager/Chart.yaml`: `0.1.99 → 0.1.100` — chart-releaser cuts a new `datafold-manager` chart release because `values.yaml` changed.
  - `charts/datafold-manager/values.yaml` `operator.image.tag`: `"1.1.69" → "1.1.70"` — predicts the next operator semver-release tag from the companion PR.

**Not bumped:** `charts/datafold/charts/operator/Chart.yaml` `appVersion`. That subchart is the legacy `kopf`-based operator at `{global.datafoldRepository}/operator:<appVersion>`; no build pipeline I could find produces a new image tag for it, so the bump would reference a non-existent image.

No CRD changes — `TemporalWorkerSettings.MaxConcurrency` is already in the schema, and clusters can still override `temporal.maxConcurrency` per `DatafoldApplication` (e.g. set saas-eu higher, leave dedicated clouds on chart default).

### Merge order

1. Review + merge this PR.
2. datafold-operator#101: re-bump the submodule pointer to this PR's merge commit, then merge it. semantic-release publishes `v1.1.70` operator image.
3. Pull latest `datafold-operator` locally; run `update-df-mgr` per operator-managed cluster.

## Test plan

- [x] CI lint + kubeconform AWS/GCP/Azure green
- [ ] After this merges, datafold-operator#101 gets re-bumped to the merge commit and lands
- [ ] After datafold-operator#101 merges, `v1.1.70` operator image exists
- [ ] `update-df-mgr` per cluster pulls the new manager chart and runs cleanly
- [ ] Per cluster verification:
  - [ ] `kubectl exec datafold-worker-io-<pod> -n <ns> -- env | grep TEMPORAL_MAX_CONCURRENCY` returns `35` (worker-io-enabled clusters: `saas-eu`, `ecolab`, `disney`, `test4`)
  - [ ] `kubectl get deploy datafold-server -n <ns> -o yaml | yq '.spec.template.spec.containers[0].readinessProbe.periodSeconds'` returns `10`
  - [ ] `/status_check` request rate (Datadog APM) drops ~50%
  - [ ] Worker-io memory usage doesn't approach the 4Gi limit under load (thread pool is cheap, but worth verifying)