### PR TITLE
[ENG-3756]: Add worker-thunderbolt worker-temporal alias

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.102
+version: 0.1.103
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/templates/crds.yaml
+++ b/charts/datafold-manager/templates/crds.yaml
@@ -3443,6 +3443,286 @@ spec:
                         format: int64
                         type: integer
                     type: object
+                  worker-thunderbolt:
+                    description: WorkerThunderbolt enables the thunderbolt temporal
+                      worker (thunderbolt queue)
+                    properties:
+                      command:
+                        description: Command is the container command (e.g. ["./manage.py",
+                          "temporal", "start-worker"])
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled specifies whether this component should
+                          be installed
+                        type: boolean
+                      extraEnv:
+                        description: ExtraEnv specifies additional environment variables
+                          (e.g. TEMPORAL_TASK_QUEUES)
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      keda:
+                        description: Keda holds KEDA scaling configuration for this
+                          temporal worker
+                        properties:
+                          activationTargetQueueSize:
+                            description: ActivationTargetQueueSize is the activation
+                              target queue size
+                            type: string
+                          authRef:
+                            description: AuthRef is the name of a TriggerAuthentication
+                              for Temporal
+                            type: string
+                          cooldownPeriod:
+                            description: CooldownPeriod is the KEDA cooldown period
+                              in seconds
+                            format: int32
+                            type: integer
+                          enabled:
+                            description: Enabled turns on KEDA scaling for this worker
+                            type: boolean
+                          maxReplicas:
+                            description: MaxReplicas is the maximum replica count
+                            format: int32
+                            type: integer
+                          minReplicas:
+                            description: MinReplicas is the minimum replica count
+                            format: int32
+                            type: integer
+                          pollingInterval:
+                            description: PollingInterval is the KEDA polling interval
+                              in seconds
+                            format: int32
+                            type: integer
+                          scaleDownStabilizationWindowSeconds:
+                            description: ScaleDownStabilizationWindowSeconds is the
+                              scale-down stabilization window
+                            format: int32
+                            type: integer
+                          targetQueueSize:
+                            description: TargetQueueSize is the target queue size
+                              for scaling
+                            type: string
+                        type: object
+                      rawValues:
+                        description: |-
+                          RawValues contains arbitrary Helm values to pass directly to this component's subchart
+                          These values will be merged with the component's default values and can override any
+                          configuration option supported by the component's Helm chart
+                        x-kubernetes-preserve-unknown-fields: true
+                      replicas:
+                        description: Replicas specifies the number of replicas for
+                          this component
+                        format: int32
+                        type: integer
+                      resources:
+                        description: Resources specifies the resource requirements
+                          for this component
+                        properties:
+                          limits:
+                            description: Limits specifies the maximum resources that
+                              can be used
+                            properties:
+                              cpu:
+                                description: CPU specifies the maximum CPU resources
+                                type: string
+                              ephemeralStorage:
+                                description: EphemeralStorage specifies the maximum
+                                  ephemeral storage (e.g. "10Gi")
+                                type: string
+                              hugepages1Gi:
+                                description: Hugepages1Gi specifies the maximum 1Gi
+                                  hugepages (e.g. "1Gi"). Requests must equal limits
+                                  for hugepages.
+                                type: string
+                              hugepages2Mi:
+                                description: Hugepages2Mi specifies the maximum 2Mi
+                                  hugepages (e.g. "128Mi"). Requests must equal limits
+                                  for hugepages.
+                                type: string
+                              memory:
+                                description: Memory specifies the maximum memory resources
+                                type: string
+                            type: object
+                          requests:
+                            description: Requests specifies the minimum resources
+                              that should be allocated
+                            properties:
+                              cpu:
+                                description: CPU specifies the minimum CPU resources
+                                type: string
+                              ephemeralStorage:
+                                description: EphemeralStorage specifies the minimum
+                                  ephemeral storage (e.g. "10Gi")
+                                type: string
+                              hugepages1Gi:
+                                description: Hugepages1Gi specifies the minimum 1Gi
+                                  hugepages (e.g. "1Gi"). Must equal limits when both
+                                  are set.
+                                type: string
+                              hugepages2Mi:
+                                description: Hugepages2Mi specifies the minimum 2Mi
+                                  hugepages (e.g. "128Mi"). Must equal limits when
+                                  both are set.
+                                type: string
+                              memory:
+                                description: Memory specifies the minimum memory resources
+                                type: string
+                            type: object
+                        type: object
+                      storage:
+                        description: Storage configures ephemeral storage for the
+                          temporal worker
+                        properties:
+                          dataSize:
+                            description: DataSize specifies the size of the storage
+                              volume (e.g. "100Gi")
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether storage is enabled
+                            type: boolean
+                          storageClass:
+                            description: StorageClass specifies the storage class
+                              for the volume
+                            type: string
+                        type: object
+                      temporal:
+                        description: Temporal holds per-worker Temporal settings (taskQueue,
+                          maxConcurrency, workerPoolType)
+                        properties:
+                          maxConcurrency:
+                            description: MaxConcurrency sets TEMPORAL_MAX_CONCURRENCY
+                            type: string
+                          taskQueue:
+                            description: TaskQueue sends tasks to a type of worker
+                            type: string
+                          workerPoolType:
+                            description: WorkerPoolType sets DATAFOLD_WORKER_POOL_TYPE
+                            type: string
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: TerminationGracePeriodSeconds is the pod termination
+                          grace period
+                        format: int64
+                        type: integer
+                    type: object
                   worker2:
                     description: Worker2 enables the second worker instance
                     properties:

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.1.70"
+    tag: "1.1.71"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.86
+version: 0.10.87
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 
@@ -59,6 +59,11 @@ dependencies:
     repository: file://charts/worker-temporal
     condition: worker-monitors.install
     alias: worker-monitors
+  - name: worker-temporal
+    version: "*.*.*"
+    repository: file://charts/worker-temporal
+    condition: worker-thunderbolt.install
+    alias: worker-thunderbolt
   - name: operator
     version: "*.*.*"
     repository: file://charts/operator

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -338,6 +338,22 @@ worker-monitors:
       cpu: 200m
       memory: 15Gi
 
+worker-thunderbolt:
+  install: true
+  replicaCount: 0
+  terminationGracePeriodSeconds: "30"
+  temporal:
+    taskQueues: "thunderbolt"
+    workerPoolType: "process"
+  keda:
+    minReplicas: 0
+  resources:
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 200m
+      memory: 6Gi
+
 worker:
   install: true
   replicaCount: 1

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -344,7 +344,7 @@ worker-thunderbolt:
   terminationGracePeriodSeconds: "30"
   temporal:
     taskQueues: "thunderbolt"
-    workerPoolType: "process"
+    workerPoolType: "thread"
   keda:
     minReplicas: 0
   resources:


### PR DESCRIPTION
> **WIP / draft** — companion to operator PR and an eventual cloud-infra PR. Posting for early review while end-to-end testing is in progress.

## Summary

Adds a new \`worker-thunderbolt\` alias of the existing \`worker-temporal\` subchart, so Thunderbolt's Temporal activities can run on a dedicated worker Deployment and be scaled/rolled independently of other Datafold workers.

- New dependency block in \`charts/datafold/Chart.yaml\` aliasing \`worker-temporal\` → \`worker-thunderbolt\` (mirrors the existing \`worker-monitors\` pattern Gerard added).
- New default values block \`worker-thunderbolt:\` in \`charts/datafold/values.yaml\`. Defaults match \`worker-monitors\` (\`install: true\`, \`replicaCount: 0\`, KEDA-scaled to zero, task queue \`thunderbolt\`).
- Chart version bump 0.10.84 → 0.10.85.

No new template — \`worker-temporal\` is generic and already aliased seven other ways.

## Context

- Linear: https://linear.app/datafold/issue/ENG-3756/uncouple-thunderbolt-temporal-workers-from-other-datafold-work
- The monitors-queue migration post-mortem ( https://datafold.slack.com/archives/C0B1QFYJKK6/p1778327545789109 ) flagged a queue-handoff hazard we want to avoid here too — see plan for the phased rollout.

## Companion PRs

- datafold-operator: WorkerThunderbolt typed component (separate PR on branch \`filip-eng-3756-thunderbolt-worker\`)
- cloud-infra: deferred — only needed once a cluster actually wants to process Thunderbolt work.

## Test plan

- [ ] Render \`helm template\` for a representative deployment with the new chart and confirm \`worker-thunderbolt\` Deployment renders at 0 replicas.
- [ ] Render with overrides setting \`replicaCount: 1\` and confirm the Deployment, SA, and (when KEDA enabled) ScaledObject all appear correctly.
- [ ] Verify the chart passes existing \`ct lint\` (if any) and that \`helm-dep-build.sh\` is a no-op.