### PR TITLE
[ENG-3846]: Add liveness probe for temporal workers

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.103
+version: 0.1.104
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.1.71"
+    tag: "1.1.72"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.87
+version: 0.10.88
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/deployment.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/deployment.yaml
@@ -103,14 +103,35 @@ spec:
             - name: TEMPORAL_METRICS_BIND_ADDRESS
               value: "0.0.0.0:{{ .Values.metrics.port }}"
             {{- end }}
+            {{- if .Values.liveness.enabled }}
+            - name: TEMPORAL_LIVENESS_PORT
+              value: {{ .Values.liveness.port | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.metrics.enabled }}
+          {{- if or .Values.metrics.enabled .Values.liveness.enabled }}
           ports:
+            {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+            {{- end }}
+            {{- if .Values.liveness.enabled }}
+            - name: liveness
+              containerPort: {{ .Values.liveness.port }}
+              protocol: TCP
+            {{- end }}
+          {{- end }}
+          {{- if .Values.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: {{ .Values.liveness.port }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.liveness.failureThreshold }}
+            timeoutSeconds: {{ .Values.liveness.timeoutSeconds }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -76,6 +76,17 @@ metrics:
   enabled: true
   port: 9090
 
+liveness:
+  # Starts a lightweight HTTP server inside the worker and wires up a K8s
+  # livenessProbe against /livez. The probe returns 503 when any Temporal worker
+  # stops running, a fatal error is raised, or the process pool becomes broken.
+  enabled: true
+  port: 8091
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  failureThreshold: 3
+  timeoutSeconds: 5
+
 extraEnv: []
 
 volumes: []


### PR DESCRIPTION
## Summary

- Adds a `liveness` section to `worker-temporal/values.yaml` (enabled by default, port 8091, 60s initial delay, 20s period, 5s timeout, 3 failures before restart)
- Sets `TEMPORAL_LIVENESS_PORT` env var so the worker starts the `/livez` HTTP server
- Exposes port 8091 as a named `liveness` container port
- Wires up a `livenessProbe` using `httpGet` to `/livez` — K8s will restart the pod when the worker reports unhealthy (worker stopped, fatal error, or broken process pool)

Depends on datafold/datafold#12364.

## Test plan

- [ ] Deploy to staging and confirm `livenessProbe` shows `Success` in pod events
- [ ] Confirm workers restart when the process pool is broken (per the test steps in the linked PR)
- [ ] Verify existing `metrics` port is unaffected when both `metrics.enabled` and `liveness.enabled` are true

🤖 Generated with [Claude Code](https://claude.com/claude-code)