### PR TITLE
fix: Bump datafold-manager default operator tag to 1.1.72 [ENG-3756]

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.103
+version: 0.1.104
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.1.71"
+    tag: "1.1.72"
     pullPolicy: Always
 
   # Operator deployment configuration


### PR DESCRIPTION
## Summary
- Bump default `operator.image.tag` from `1.1.71` → `1.1.72` in `charts/datafold-manager/values.yaml`.
- Chart `0.1.103` → `0.1.104`.

## Why
Chart 0.1.103 (PR #328) pinned `1.1.71`, but operator `1.1.72` (datafold-operator#105) bumped the helm-charts submodule to include the `worker-thunderbolt` alias. Without this bump, `update-df-mgr` deploys an operator whose typed `WorkerThunderbolt` field exists but whose bundled umbrella chart doesn't know the alias.

## Test plan
- [ ] `helm template charts/datafold-manager` renders with tag `1.1.72`.