### PR TITLE
[ENG-3935]: Give worker-thunderbolt 30min graceful shutdown

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.87
+version: 0.10.88
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/deployment.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/deployment.yaml
@@ -99,6 +99,10 @@ spec:
             - name: DATAFOLD_WORKER_POOL_TYPE
               value: {{ .Values.temporal.workerPoolType | quote }}
             {{- end }}
+            {{- if .Values.temporal.gracefulShutdownTimeout }}
+            - name: TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: {{ .Values.temporal.gracefulShutdownTimeout | quote }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: TEMPORAL_METRICS_BIND_ADDRESS
               value: "0.0.0.0:{{ .Values.metrics.port }}"

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -55,6 +55,8 @@ temporal:
   maxConcurrency: "5"
   # workerPoolType sets DATAFOLD_WORKER_POOL_TYPE. Leave empty for the default pool type.
   workerPoolType: "thread"
+  # gracefulShutdownTimeout sets TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT. Must be ≤ terminationGracePeriodSeconds. Empty leaves it unset.
+  gracefulShutdownTimeout: ""
 
 keda:
   enabled: false

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -341,10 +341,11 @@ worker-monitors:
 worker-thunderbolt:
   install: true
   replicaCount: 0
-  terminationGracePeriodSeconds: "30"
+  terminationGracePeriodSeconds: "1800"
   temporal:
     taskQueues: "thunderbolt"
     workerPoolType: "thread"
+    gracefulShutdownTimeout: "1800"
   keda:
     minReplicas: 0
   resources:


### PR DESCRIPTION
## Summary

Worker pods running long LLM agent activities (`run_agent_activity`, `start_to_close=2h`) were SIGKILLed 30s after SIGTERM, orphaning in-flight activities. Orphaned activities surface as `Heartbeat timeout` errors on the Temporal side and reset the ticket — wasting the LLM run and bumping the crash counter toward auto-escalation.

Root cause: chart default `terminationGracePeriodSeconds: "30"` ≪ code default `TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT=18000` (5h) ≪ activity `start_to_close=2h`. K8s wins the race every time.

## Changes

- **subchart `worker-temporal`**: add `temporal.gracefulShutdownTimeout` value; wire `TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT` env var into the deployment when set. Empty default (no env injected) means existing aliases are unaffected.
- **parent `datafold/values.yaml`**: for `worker-thunderbolt` only, set `terminationGracePeriodSeconds: "1800"` and `temporal.gracefulShutdownTimeout: "1800"`. Other aliases untouched.
- Parent chart version bump `0.10.87` → `0.10.88`.