### PR TITLE
[ENG-3964]: Set worker-thunderbolt to process pool

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.92
+version: 0.10.93
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -331,7 +331,7 @@ worker-thunderbolt:
   terminationGracePeriodSeconds: "1800"
   temporal:
     taskQueues: "thunderbolt"
-    workerPoolType: "thread"
+    workerPoolType: "process"
     gracefulShutdownTimeout: "1800"
   keda:
     minReplicas: 0


### PR DESCRIPTION
## Summary
- Flips `worker-thunderbolt.temporal.workerPoolType` from `thread` to `process` in `charts/datafold/values.yaml`, matching the other long-LLM workers (`worker-compute`, `worker-highmem`, `worker-storage[-high]`, `worker-monitors`).
- Bumps `charts/datafold/Chart.yaml` from `0.10.89` to `0.10.90`.

## Why
ENG-3935 surfaced heartbeat timeouts on `worker-thunderbolt` under heavy concurrent agent dispatches — GIL contention in `thread` pool mode starves the heartbeat daemon thread. Sibling long-LLM workers all use `process` pool, where the SDK's `SharedHeartbeatSender` routes heartbeats via a cross-process queue and is decoupled from any one process's GIL. `worker-thunderbolt` was inadvertently left on `thread`.

A live saas override (`spec.components.worker-thunderbolt.rawValues.temporal.workerPoolType: "process"`) has been applied since 2026-05-20 with no regressions over the bake-in window.

Once this is merged and the operator picks it up, the per-cluster `rawValues` override on saas (and ecolab, if applied) can be dropped.

Ref: [ENG-3964](https://linear.app/datafold/issue/ENG-3964/reminder-2026-05-27-if-saas-worker-thunderbolt-process-pool-patch), [ENG-3935](https://linear.app/datafold/issue/ENG-3935/investigate-agentworkflow-heartbeat-timeouts-in-prod), #331.

## Test plan
- [ ] Render the chart and confirm only the worker-thunderbolt pool type changes.
- [ ] After merge + operator pickup on saas, verify no heartbeat timeouts and agent runs complete normally.
- [ ] Drop the per-cluster `rawValues.temporal.workerPoolType` override on saas (and ecolab if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)