### PR TITLE
values: drop stale worker-temporal mentions in comments

### DIFF
--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -66,7 +66,7 @@ global:
     maintenanceWindow: ""
   temporal:
     address: "temporal-frontend.temporal.svc.cluster.local:7233"
-    # Temporal worker StorageClass (templates/storageclass.yaml) metadata.name and PVC storageClassName (worker-temporal).
+    # Temporal worker StorageClass (templates/storageclass.yaml) metadata.name and PVC storageClassName.
     storageClassName: sc-datafold-temporal
     # Set false if the cluster already provides a StorageClass with storageClassName.
     createStorageClass: true
@@ -106,7 +106,7 @@ global:
       # below. When set, takes precedence over the built-in AES-256-GCM codec.
       codecClass: ""
       # customCodec: mounts a customer-supplied Python file from a ConfigMap into both
-      # the server and worker-temporal containers at /datafold/plugins/<fileName>.
+      # the server and all temporal worker containers at /datafold/plugins/<fileName>.
       # The loader resolves TEMPORAL_CODEC_CLASS by looking up <module_stem>.py in that
       # fixed directory — no PYTHONPATH manipulation needed.
       # codecClass should use the bare stem, e.g. "temporal_codec:KMSCodec"


### PR DESCRIPTION
## Summary

Two stale `worker-temporal` references in `charts/datafold/values.yaml` comments. `worker-temporal` no longer exists as a releasable worker — it only exists as the shared subchart that every per-queue worker (`worker-thunderbolt`, `worker-io`, `worker-compute`, `worker-highmem`, `worker-storage`, `worker-storage-high`, `worker-monitors`, `worker-catalog`, `worker-lineage`, `worker-monitor`, `worker-singletons`, `worker-interactive`) aliases via `Chart.yaml`.

| line | before | after |
|---|---|---|
| 69 | `# Temporal worker StorageClass ... and PVC storageClassName (worker-temporal).` | `# Temporal worker StorageClass ... and PVC storageClassName.` |
| 109 | `# the server and worker-temporal containers at /datafold/plugins/<fileName>.` | `# the server and all temporal worker containers at /datafold/plugins/<fileName>.` |

The L109 wording was actively misleading: the custom codec mounts into **all** temporal worker pods (every alias of the worker-temporal subchart), not just one container named `worker-temporal`.

## Verification

```
$ grep -n worker-temporal charts/datafold/values.yaml
(no matches)
```

## Test plan

- [x] No remaining `worker-temporal` references in `values.yaml`
- [x] No semantic change — both edits are comment-only
- [ ] CI checks

Pure docs change, 2 lines edited.