### PR TITLE
[ENG-4050]: Add worker-repo-mirror sub-chart

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.111
+version: 0.1.112
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.110
+version: 0.1.111
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/templates/crds.yaml
+++ b/charts/datafold-manager/templates/crds.yaml
@@ -2529,6 +2529,288 @@ spec:
                         format: int64
                         type: integer
                     type: object
+                  worker-repo-mirror:
+                    description: |-
+                      WorkerRepoMirror enables the repo-mirror temporal worker (repo-mirror queue).
+                      Stateful single-replica worker that serves a git read-cache to other workers;
+                      uses Storage to back the bare repos PVC.
+                    properties:
+                      command:
+                        description: Command is the container command (e.g. ["./manage.py",
+                          "temporal", "start-worker"])
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled specifies whether this component should
+                          be installed
+                        type: boolean
+                      extraEnv:
+                        description: ExtraEnv specifies additional environment variables
+                          (e.g. TEMPORAL_TASK_QUEUES)
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      keda:
+                        description: Keda holds KEDA scaling configuration for this
+                          temporal worker
+                        properties:
+                          activationTargetQueueSize:
+                            description: ActivationTargetQueueSize is the activation
+                              target queue size
+                            type: string
+                          authRef:
+                            description: AuthRef is the name of a TriggerAuthentication
+                              for Temporal
+                            type: string
+                          cooldownPeriod:
+                            description: CooldownPeriod is the KEDA cooldown period
+                              in seconds
+                            format: int32
+                            type: integer
+                          enabled:
+                            description: Enabled turns on KEDA scaling for this worker
+                            type: boolean
+                          maxReplicas:
+                            description: MaxReplicas is the maximum replica count
+                            format: int32
+                            type: integer
+                          minReplicas:
+                            description: MinReplicas is the minimum replica count
+                            format: int32
+                            type: integer
+                          pollingInterval:
+                            description: PollingInterval is the KEDA polling interval
+                              in seconds
+                            format: int32
+                            type: integer
+                          scaleDownStabilizationWindowSeconds:
+                            description: ScaleDownStabilizationWindowSeconds is the
+                              scale-down stabilization window
+                            format: int32
+                            type: integer
+                          targetQueueSize:
+                            description: TargetQueueSize is the target queue size
+                              for scaling
+                            type: string
+                        type: object
+                      rawValues:
+                        description: |-
+                          RawValues contains arbitrary Helm values to pass directly to this component's subchart
+                          These values will be merged with the component's default values and can override any
+                          configuration option supported by the component's Helm chart
+                        x-kubernetes-preserve-unknown-fields: true
+                      replicas:
+                        description: Replicas specifies the number of replicas for
+                          this component
+                        format: int32
+                        type: integer
+                      resources:
+                        description: Resources specifies the resource requirements
+                          for this component
+                        properties:
+                          limits:
+                            description: Limits specifies the maximum resources that
+                              can be used
+                            properties:
+                              cpu:
+                                description: CPU specifies the maximum CPU resources
+                                type: string
+                              ephemeralStorage:
+                                description: EphemeralStorage specifies the maximum
+                                  ephemeral storage (e.g. "10Gi")
+                                type: string
+                              hugepages1Gi:
+                                description: Hugepages1Gi specifies the maximum 1Gi
+                                  hugepages (e.g. "1Gi"). Requests must equal limits
+                                  for hugepages.
+                                type: string
+                              hugepages2Mi:
+                                description: Hugepages2Mi specifies the maximum 2Mi
+                                  hugepages (e.g. "128Mi"). Requests must equal limits
+                                  for hugepages.
+                                type: string
+                              memory:
+                                description: Memory specifies the maximum memory resources
+                                type: string
+                            type: object
+                          requests:
+                            description: Requests specifies the minimum resources
+                              that should be allocated
+                            properties:
+                              cpu:
+                                description: CPU specifies the minimum CPU resources
+                                type: string
+                              ephemeralStorage:
+                                description: EphemeralStorage specifies the minimum
+                                  ephemeral storage (e.g. "10Gi")
+                                type: string
+                              hugepages1Gi:
+                                description: Hugepages1Gi specifies the minimum 1Gi
+                                  hugepages (e.g. "1Gi"). Must equal limits when both
+                                  are set.
+                                type: string
+                              hugepages2Mi:
+                                description: Hugepages2Mi specifies the minimum 2Mi
+                                  hugepages (e.g. "128Mi"). Must equal limits when
+                                  both are set.
+                                type: string
+                              memory:
+                                description: Memory specifies the minimum memory resources
+                                type: string
+                            type: object
+                        type: object
+                      storage:
+                        description: Storage configures ephemeral storage for the
+                          temporal worker
+                        properties:
+                          dataSize:
+                            description: DataSize specifies the size of the storage
+                              volume (e.g. "100Gi")
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether storage is enabled
+                            type: boolean
+                          storageClass:
+                            description: StorageClass specifies the storage class
+                              for the volume
+                            type: string
+                        type: object
+                      temporal:
+                        description: Temporal holds per-worker Temporal settings (taskQueue,
+                          maxConcurrency, workerPoolType)
+                        properties:
+                          maxConcurrency:
+                            description: MaxConcurrency sets TEMPORAL_MAX_CONCURRENCY
+                            type: string
+                          taskQueue:
+                            description: TaskQueue sends tasks to a type of worker
+                            type: string
+                          workerPoolType:
+                            description: WorkerPoolType sets DATAFOLD_WORKER_POOL_TYPE
+                            type: string
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: TerminationGracePeriodSeconds is the pod termination
+                          grace period
+                        format: int64
+                        type: integer
+                    type: object
                   worker-singletons:
                     description: WorkerSingletons enables the singletons worker
                     properties:

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.96
+version: 0.10.97
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.95
+version: 0.10.96
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 
@@ -59,6 +59,10 @@ dependencies:
     repository: file://charts/worker-temporal
     condition: worker-thunderbolt.install
     alias: worker-thunderbolt
+  - name: worker-repo-mirror
+    version: "*.*.*"
+    repository: file://charts/worker-repo-mirror
+    condition: worker-repo-mirror.install
   - name: operator
     version: "*.*.*"
     repository: file://charts/operator

--- a/charts/datafold/charts/worker-repo-mirror/Chart.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: worker-repo-mirror
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/datafold/charts/worker-repo-mirror/templates/_helpers.tpl
+++ b/charts/datafold/charts/worker-repo-mirror/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "worker-repo-mirror.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name. Mirrors worker-temporal's pattern for consistency
+with `datafold-worker-*` naming in the cluster.
+*/}}
+{{- define "worker-repo-mirror.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "worker-repo-mirror.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Service Account name.
+*/}}
+{{- define "worker-repo-mirror.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- include "worker-repo-mirror.name" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service name. The parent chart can reach the service at
+`<svc-name>.<release-namespace>.svc`.
+*/}}
+{{- define "worker-repo-mirror.serviceName" -}}
+{{- default "repo-mirror" .Values.service.name }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "worker-repo-mirror.labels" -}}
+helm.sh/chart: {{ include "worker-repo-mirror.chart" . }}
+app.kubernetes.io/component: {{ include "worker-repo-mirror.name" . }}
+{{ include "worker-repo-mirror.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{ include "datafold.labels" . }}
+{{- end }}
+
+{{/*
+Selector labels. `part-of: datafold` matches the convention used by every
+other Datafold workload — gives all workers a single selector for
+namespace-wide policies.
+*/}}
+{{- define "worker-repo-mirror.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "worker-repo-mirror.name" . }}
+app.kubernetes.io/part-of: datafold
+{{- end }}
+
+{{/*
+Datadog log autodiscovery annotation. Same shape as worker-temporal so
+log routing is uniform.
+*/}}
+{{- define "worker-repo-mirror.datadog.annotations" -}}
+{{- if (eq .Values.global.datadog.install true) }}
+ad.datadoghq.com/{{ .Chart.Name }}.logs: >-
+  [{
+    "source": "datafold-{{ .Chart.Name }}",
+    "service": "datafold-{{ .Chart.Name }}",
+    "log_processing_rules": [{
+      "type": "multi_line",
+      "name": "log_start_with_date",
+      "pattern" : "\\[\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\,\\d{3}\\]"
+    }]
+  }]
+{{- end }}
+{{- end }}
+
+{{/*
+Datafold annotations. Keeps replica-count visible in `kubectl describe pod`,
+matching the worker-temporal convention.
+*/}}
+{{- define "worker-repo-mirror.datafold.annotations" -}}
+replica-count: "{{ .Values.replicaCount }}"
+{{- with .Values.podAnnotations }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+PVC storageClassName resolution. Precedence:
+  1. .Values.storage.storageClass (per-env override)
+  2. global.temporal.storageClassName (cluster-wide default for temporal workers)
+  3. literal "sc-datafold-temporal" (cluster default name)
+Mirrors worker-temporal's helper of the same shape.
+*/}}
+{{- define "worker-repo-mirror.effectiveStorageClassName" -}}
+{{- if .Values.storage.storageClass -}}
+{{- .Values.storage.storageClass | toString | trim -}}
+{{- else if and .Values.global.temporal .Values.global.temporal.storageClassName -}}
+{{- .Values.global.temporal.storageClassName | toString | trim -}}
+{{- else -}}
+sc-datafold-temporal
+{{- end -}}
+{{- end }}

--- a/charts/datafold/charts/worker-repo-mirror/templates/networkpolicy.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "worker-repo-mirror.fullname" . }}-ingress
+  labels:
+    {{- include "worker-repo-mirror.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "worker-repo-mirror.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Same-namespace ingress only. Empty podSelector with no
+    # namespaceSelector is the k8s idiom for "this namespace only."
+    - from:
+        - podSelector: {}
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/datafold/charts/worker-repo-mirror/templates/service.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "worker-repo-mirror.serviceName" . }}
+  labels:
+    {{- include "worker-repo-mirror.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: git
+      port: {{ .Values.service.port }}
+      targetPort: git
+      protocol: TCP
+  selector:
+    {{- include "worker-repo-mirror.selectorLabels" . | nindent 4 }}

--- a/charts/datafold/charts/worker-repo-mirror/templates/serviceaccount.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/templates/serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "worker-repo-mirror.serviceAccountName" . }}
+  labels:
+    {{- include "worker-repo-mirror.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+    {{- if (eq .Values.global.cloudProvider "aws") }}
+    {{- if .Values.serviceAccount.roleArn }}
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.chartAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/datafold/charts/worker-repo-mirror/templates/statefulset.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/templates/statefulset.yaml
@@ -1,0 +1,177 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "worker-repo-mirror.fullname" . }}
+  labels:
+    {{- include "worker-repo-mirror.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "worker-repo-mirror.serviceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: OrderedReady
+  selector:
+    matchLabels:
+      {{- include "worker-repo-mirror.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- include "worker-repo-mirror.datafold.annotations" . | nindent 8 }}
+        {{- include "worker-repo-mirror.datadog.annotations" . | nindent 8 }}
+        {{- if .Values.metrics.enabled }}
+        # Datadog autodiscovery for Temporal SDK metrics. See
+        # worker-temporal/templates/deployment.yaml for the full rationale.
+        ad.datadoghq.com/{{ .Chart.Name }}.checks: |
+          {
+            "openmetrics": {
+              "instances": [{
+                "openmetrics_endpoint": "http://%%host%%:{{ .Values.metrics.port }}/metrics",
+                "namespace": "temporal_worker",
+                "metrics": ["temporal_.*"],
+                "tag_by_endpoint": false,
+                "include_labels": [
+                  "task_queue",
+                  "workflow_type",
+                  "activity_type"
+                ],
+                "collect_histogram_buckets": true,
+                "histogram_buckets_as_distributions": true,
+                "exclude_metrics_by_labels": {
+                  "task_queue": ["^sticky\\."]
+                }
+              }]
+            }
+          }
+        {{- end }}
+      labels:
+        {{- include "worker-repo-mirror.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "worker-repo-mirror.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.global.shellRepository }}/{{ .Values.global.datafoldImage }}:{{ .Values.global.datafoldVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- toYaml .Values.command | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "datafold.configmap" . }}
+            {{- if or .Values.global.temporal.encryption.keys .Values.global.temporal.encryption.externalSecretName }}
+            - secretRef:
+                name: {{ include "datafold.temporal.encryptionSecretName" . }}
+            {{- end }}
+          env:
+            {{ include "datafold.env" . | nindent 12 }}
+            - name: DATAFOLD_DATADOG_CLIENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_DATADOG_CLIENT_TOKEN
+            - name: DATAFOLD_DATADOG_APPLICATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datafold.secrets" . }}
+                  key: DATAFOLD_DATADOG_APPLICATION_ID
+            {{- if .Values.temporal.taskQueues }}
+            - name: TEMPORAL_TASK_QUEUES
+              value: {{ .Values.temporal.taskQueues | quote }}
+            {{- end }}
+            {{- if .Values.temporal.maxConcurrency }}
+            - name: TEMPORAL_MAX_CONCURRENCY
+              value: {{ .Values.temporal.maxConcurrency | quote }}
+            {{- end }}
+            {{- if .Values.temporal.workerPoolType }}
+            - name: DATAFOLD_WORKER_POOL_TYPE
+              value: {{ .Values.temporal.workerPoolType | quote }}
+            {{- end }}
+            {{- if .Values.temporal.gracefulShutdownTimeout }}
+            - name: TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: {{ .Values.temporal.gracefulShutdownTimeout | quote }}
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: TEMPORAL_METRICS_BIND_ADDRESS
+              value: "0.0.0.0:{{ .Values.metrics.port }}"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: git
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: repos
+              mountPath: {{ .Values.storage.mountPath }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.global.temporal.encryption.customCodec.configMapName }}
+            - name: datafold-plugins
+              mountPath: /datafold/plugins
+              readOnly: true
+            {{- end }}
+      {{- if or .Values.volumes .Values.global.temporal.encryption.customCodec.configMapName }}
+      volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.temporal.encryption.customCodec.configMapName }}
+        - name: datafold-plugins
+          configMap:
+            name: {{ .Values.global.temporal.encryption.customCodec.configMapName }}
+            items:
+              - key: {{ .Values.global.temporal.encryption.customCodec.fileName }}
+                path: {{ .Values.global.temporal.encryption.customCodec.fileName }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: repos
+        labels:
+          {{- include "worker-repo-mirror.labels" . | nindent 10 }}
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ include "worker-repo-mirror.effectiveStorageClassName" . | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.dataSize | quote }}

--- a/charts/datafold/charts/worker-repo-mirror/values.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/values.yaml
@@ -1,0 +1,79 @@
+replicaCount: 1
+
+image:
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets:
+  - name: datafold-docker-secret
+
+nameOverride: ""
+fullnameOverride: ""
+
+terminationGracePeriodSeconds: "30"
+
+command:
+  - "repo_mirror_worker"
+
+serviceAccount:
+  create: false
+  automount: true
+  annotations: {}
+  roleArn: ""
+  name: "worker"
+
+podAnnotations: {}
+podLabels: {}
+
+chartLabels: {}
+chartAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  allowPrivilegeEscalation: false
+
+storage:
+  dataSize: "32Gi"
+  # Empty falls back to global.temporal.storageClassName then to the
+  # chart default (see _helpers.tpl).
+  storageClass: ""
+  mountPath: "/repos"
+
+resources:
+  limits:
+    memory: 2Gi
+  requests:
+    cpu: 200m
+    memory: 2Gi
+
+temporal:
+  taskQueues: "repomirror"
+  maxConcurrency: "10"
+  workerPoolType: "thread"
+  # Must be ≤ terminationGracePeriodSeconds.
+  gracefulShutdownTimeout: "20"
+
+service:
+  type: ClusterIP
+  name: "repo-mirror"
+  port: 9418
+
+networkPolicy:
+  enabled: true
+
+metrics:
+  enabled: true
+  port: 9090
+
+extraEnv: []
+volumes: []
+volumeMounts: []
+nodeSelector: {}
+tolerations: []
+affinity: {}
+initContainers: []

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -342,6 +342,9 @@ worker-thunderbolt:
       cpu: 200m
       memory: 6Gi
 
+worker-repo-mirror:
+  install: false
+
 worker:
   install: true
   replicaCount: 1


### PR DESCRIPTION
## Summary

- New `worker-repo-mirror` sub-chart: single-replica StatefulSet with a 32 GiB RWO PVC (`volumeClaimTemplates`), ClusterIP Service on port 9418, and a same-namespace-only NetworkPolicy.
- Reuses the existing `worker` ServiceAccount; no new IRSA.
- Off by default in the parent chart (`worker-repo-mirror.install: false`); opt-in per deployment.
- `datafold-manager` CRD regenerated to expose the new `WorkerRepoMirror` field on `DatafoldApplication.spec.components`.

## Versions

- `datafold` → `0.10.96`
- `datafold-manager` → `0.1.111`

## Test plan

- [x] `helm dependency build` succeeds
- [x] `helm lint --set worker-repo-mirror.install=true charts/datafold` passes
- [x] `helm template` renders the StatefulSet, Service, and NetworkPolicy correctly with `install=true`; nothing renders with the default `install=false`
- [ ] CI: `lint`, `kubeconform`, `jeeves-check` pass
- [ ] End-to-end soak in `testing` cluster after the corresponding operator + cloud-infra changes land