### PR TITLE
fix: Add traffic policy for nginx

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.110
+version: 0.1.111
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.2.4"
+    tag: "1.2.5"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.95
+version: 0.10.96
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/nginx/templates/_helpers.tpl
+++ b/charts/datafold/charts/nginx/templates/_helpers.tpl
@@ -250,3 +250,14 @@ NEG annotations for Google Cloud (in the service)
 nodePort: {{ .Values.service.nodePort }}
 {{- end }}
 {{- end }}
+
+{{/*
+externalTrafficPolicy for the nginx Service. AWS only: avoids a cross-node hop
+that the EKS node security group blocks, which causes ALB 504s with >1 replica.
+Invalid on the ClusterIP Services used by GCP/Azure.
+*/}}
+{{- define "nginx.externalTrafficPolicy" -}}
+{{- if (eq .Values.global.cloudProvider "aws") -}}
+externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | default "Local" }}
+{{- end }}
+{{- end }}

--- a/charts/datafold/charts/nginx/templates/service.yaml
+++ b/charts/datafold/charts/nginx/templates/service.yaml
@@ -23,3 +23,4 @@ spec:
     app.kubernetes.io/name: {{ include "nginx.name" . }}
   sessionAffinity: None
   type: {{ include "nginx.serviceType" . }}
+{{- include "nginx.externalTrafficPolicy" . | nindent 2 }}

--- a/charts/datafold/charts/nginx/values.yaml
+++ b/charts/datafold/charts/nginx/values.yaml
@@ -25,6 +25,9 @@ service:
   typeOverride: ""
   nodePort: 31337
   loadBalancerIps: []
+  # AWS only. "Local" avoids the cross-node hop that causes ALB 504s with >1
+  # replica. Ignored on GCP/Azure. See "nginx.externalTrafficPolicy".
+  externalTrafficPolicy: "Local"
 
 ingress:
   deploy: false


### PR DESCRIPTION
*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
