### PR TITLE
[BOYSCOUT]: Log request_time + upstream timings in nginx access log

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.98
+version: 0.10.99
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/nginx/templates/config-map.yaml
+++ b/charts/datafold/charts/nginx/templates/config-map.yaml
@@ -21,7 +21,16 @@ data:
         # include /etc/nginx/mime.types;
         default_type application/octet-stream;
 
-        access_log /var/log/nginx/access.log;
+        # Mirrors nginx's built-in "combined" format and appends upstream timing
+        # fields (request time + upstream connect/header/response time) so we have
+        # per-request latency visibility in the access log.
+        log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+                                  '"$request" $status $body_bytes_sent '
+                                  '"$http_referer" "$http_user_agent" '
+                                  'rt=$request_time uct=$upstream_connect_time '
+                                  'uht=$upstream_header_time urt=$upstream_response_time';
+
+        access_log /var/log/nginx/access.log timed_combined;
         error_log /var/log/nginx/error.log;
 
         gzip on;


### PR DESCRIPTION
## What

Add an explicit `timed_combined` nginx `log_format` that mirrors nginx's built-in `combined` format and appends per-request timing fields, then points the main `access_log` at it:

```
rt=$request_time uct=$upstream_connect_time uht=$upstream_header_time urt=$upstream_response_time
```

All existing combined-format fields are preserved; this is purely additive. No routing, timeouts, or proxy behavior changed.

## Why

We need per-request latency visibility for the `/status_check` path and Stack-is-down investigations. Today the synthetic only sees a binary up/down and there's no APM on this proxy path, so a slow-but-up backend is invisible. Logging `request_time` + upstream timings gives us that signal at the nginx layer.

## Follow-up

A follow-up is needed on the Datadog side to parse `rt`/`urt` out of the access log into a log-based metric.

## Validation

`helm`/`nginx` aren't available in this environment. Validated by parsing the ConfigMap `data` block as YAML (clean), confirming the `nginx.conf` literal scalar contains the new `log_format` + timed `access_log`, and verifying nginx `log_format` syntax (concatenated quoted strings, named format referenced in `access_log`) and balanced `{}` blocks.