### PR TITLE
[BOYSCOUT] server: add PodDisruptionBudget (mirror nginx)

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.99
+version: 0.10.100
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/poddisruptionbudget.yaml
+++ b/charts/datafold/charts/server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "server.fullname" . }}
+  labels:
+    {{- include "server.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/datafold/charts/server/values.yaml
+++ b/charts/datafold/charts/server/values.yaml
@@ -1,5 +1,14 @@
 replicaCount: 2
 
+# Keep at least one server replica serving during voluntary disruptions
+# (node drains / upgrades / cluster-autoscaler scale-down). Mirrors the nginx
+# chart's PDB. Set EITHER maxUnavailable OR minAvailable; if minAvailable is
+# non-empty it takes precedence, otherwise maxUnavailable is used.
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+  minAvailable: ""
+
 image:
   pullPolicy: IfNotPresent
   tag: ""


### PR DESCRIPTION
## What
Adds a `PodDisruptionBudget` to the **server** chart, mirroring the one the
**nginx** chart already ships. New `templates/poddisruptionbudget.yaml`
(identical to nginx's, with `server.*` helpers) + a `podDisruptionBudget`
block in `server/values.yaml` (`enabled: true`, `maxUnavailable: 1`).

## Why
The server Deployment had **no PDB**. `strategy.rollingUpdate.maxUnavailable: 0`
only protects the **rolling-update** path — it does **not** govern the
**eviction** path (node drains/upgrades, cluster-autoscaler scale-down), which
is bounded only by a PDB.

The 2 server replicas are pinned to separate nodes by required pod
anti-affinity, so a simultaneous 2-node drain / scale-down can evict **both at
once**. Since the liveness+readiness probes hit `/status_check`, losing both
replicas drops the ALB to 0 healthy targets and pages
`[<deployment>] Stack is down` — a recurring SaaS noise source this is part of
addressing.

`maxUnavailable: 1` (not `minAvailable: 2`, which would block drains and
autoscaler scale-down entirely). nginx has run this exact PDB in prod for days.

## Notes
- Chart version bumped `0.10.98 → 0.10.100` (`0.10.99` is taken by open
  PR #347; `ct lint` requires a bump). May need a re-bump at merge depending on
  merge order with #347.
- Render not validated locally (no helm CLI); relying on CI (`ct lint` +
  Kubeconform), same as #347.
