### PR TITLE
[BOYSCOUT]: Point datafold-manager at operator 1.3.1 (server PDB + nginx logging)

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.112
+version: 0.1.113
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.2.5"
+    tag: "1.3.1"
     pullPolicy: Always
 
   # Operator deployment configuration


### PR DESCRIPTION
## What
Point `datafold-manager` at the **operator image `1.3.1`** (just published by datafold-operator #116 → semantic-release v1.3.1), so `update-df-mgr` deploys the controller that bakes in the server PDB (#348) + nginx request_time logging (#347).

- `charts/datafold-manager/values.yaml` `operator.image.tag`: `1.2.5` → `1.3.1`
- `charts/datafold-manager/Chart.yaml` version: `0.1.112` → `0.1.113`

## Why this is a follow-up
The four release bumps that normally travel together were missed on #347/#348 (only the `datafold` chart version moved). #116 already advanced the operator submodule and published the new image; this PR repoints the manager at it.

## Left intentionally unchanged
- `charts/datafold/charts/operator/Chart.yaml` `appVersion` stays `1.2.14` — that's the `.../datafold/operator` image v1.3.1 actually published (it wasn't bumped in #116), so bumping it here would reference a non-existent tag.
- `charts/datafold/Chart.yaml` already at `0.10.100` (from #348).

## Before rollout
Confirm `us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator:1.3.1` exists in GAR. Then `update-df-mgr` per cluster: **staging → SaaS → dedicated**.
