### PR TITLE
[BOYSCOUT]: Raise default server web workers from 3 to 6

### DIFF
--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -144,7 +144,7 @@ nginx:
   install: true
 
 config:
-  webWorkers: "3"
+  webWorkers: "6"
   workerCount: "15"
   githubServer: ""
   portalCertData: ""


### PR DESCRIPTION
## What
Raise the default gunicorn web worker count from **3 → 6** (`config.webWorkers` → `DATAFOLD_WEB_WORKERS` → `gunicorn --workers`).

## Why
More request-concurrency headroom for the server under load; the 3-worker default can bottleneck when concurrent request volume is high.

## Impact
- Umbrella-chart default, so it applies to any deployment not overriding `config.webWorkers`.
- Modest resource impact: ample memory/CPU headroom; the per-worker DB connection pool baseline grows proportionally but stays well within limits.