### PR TITLE
[BOYSCOUT]: Grant manager namespaced roles/rolebindings rbac

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.114
+version: 0.1.115
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/templates/rbac.yaml
+++ b/charts/datafold-manager/templates/rbac.yaml
@@ -95,12 +95,17 @@ rules:
   - patch
   - update
   - watch
-# Manage ClusterRole/ClusterRoleBinding for the datafold-operator (primary and secondary).
+# Manage (Cluster)Role/(Cluster)RoleBinding for the datafold-operator (primary and secondary).
+# Namespaced roles/rolebindings are needed because the datadog subchart renders a
+# Role + RoleBinding in the temporal namespace (temporal-secrets); without these
+# verbs the operator's chart apply fails pre-flight when that resource is present.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
+  - rolebindings
   verbs:
   - create
   - get

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.3.3"
+    tag: "1.3.4"
     pullPolicy: Always
 
   # Operator deployment configuration


### PR DESCRIPTION
## What

Add `roles` and `rolebindings` to the `rbac.authorization.k8s.io` rule in the `datafold-manager` ClusterRole (`datafold-manager-role`), which previously granted only `clusterroles`/`clusterrolebindings`.

Also:
- bump `charts/datafold-manager/Chart.yaml` version `0.1.114` → `0.1.115` so chart-releaser publishes it
- align `charts/datafold-manager/values.yaml` `operator.image.tag` `1.3.3` → `1.3.4` (the previous value lagged the current operator release)

## Why

The `datadog` subchart renders a `Role` + `RoleBinding` (`…-temporal-secrets`) in the **`temporal`** namespace. The operator applies the rendered chart using the manager service account, but that account's ClusterRole had no permission over namespaced `roles`/`rolebindings`. As a result the chart apply fails pre-flight with `cannot get resource "roles" … in the namespace "temporal"`, and the operator cannot reconcile once that resource is present. Granting the two namespaced resources fixes the apply.

## Validation

`helm template` confirms the rendered `datafold-manager-role` ClusterRole now lists `clusterroles, clusterrolebindings, roles, rolebindings`. CI (`ct lint` / Kubeconform) validates rendering.