### PR TITLE
[BOYSCOUT]: Revert server probe repoint to /status_check

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.115
+version: 0.1.116
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.3.4"
+    tag: "1.3.5"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.101
+version: 0.10.102
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/nginx/templates/config-map.yaml
+++ b/charts/datafold/charts/nginx/templates/config-map.yaml
@@ -74,20 +74,6 @@ data:
                 return 200 "healthy\n";
             }
 
-            # /livez and /readyz are internal Kubernetes probe endpoints. The
-            # kubelet reaches them on the pod directly (not through nginx), so the
-            # 404 here does not affect health checking. They are not part of the
-            # public surface; keep them unreachable from outside the cluster.
-            location = /livez {
-                access_log off;
-                return 404;
-            }
-
-            location = /readyz {
-                access_log off;
-                return 404;
-            }
-
             location /datadog-browser-intake {
                 rewrite ^/datadog-browser-intake(/.*)$ $1 break;
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
               protocol: TCP
           startupProbe:
             httpGet:
-              path: /readyz?token={{ .Values.global.statusCheckToken }}
+              path: /status_check?token={{ .Values.global.statusCheckToken }}
               port: server
               scheme: HTTP
               httpHeaders:
@@ -149,7 +149,7 @@ spec:
           livenessProbe:
             failureThreshold: 10
             httpGet:
-              path: /livez?token={{ .Values.global.statusCheckToken }}
+              path: /status_check?token={{ .Values.global.statusCheckToken }}
               port: server
               scheme: HTTP
               httpHeaders:
@@ -163,7 +163,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /readyz?token={{ .Values.global.statusCheckToken }}
+              path: /status_check?token={{ .Values.global.statusCheckToken }}
               port: server
               scheme: HTTP
               httpHeaders:


### PR DESCRIPTION
## What

Reverts the server probe repoint from #350 — restores `livenessProbe`/`readinessProbe`/`startupProbe` to `/status_check?token=…` and removes the nginx `location = /livez` / `= /readyz` 404 blocks. The namespaced `roles`/`rolebindings` rbac fix (#352) is **kept**.

Version bumps: `datafold` `0.10.101`→`0.10.102`, `datafold-manager` `0.1.115`→`0.1.116`, `operator.image.tag` `1.3.4`→`1.3.5`.

## Why

Kubernetes `httpGet` probes do **not** deliver a query string — kubelet sends the bare path, so the `?token=` that the `/livez` and `/readyz` handlers require never reaches the server. `/readyz` returns 403 unconditionally without the token (and `/livez` once its token cache is primed), so the probes fail and the server pod crash-loops. `/status_check` returns 200 for a token-less probe, so it is the safe target.

The probe repoint will be re-introduced once the endpoints accept the token via a mechanism kubelet *can* deliver (HTTP header), tracked separately.

## Validation

Confirmed on a staging server pod: `GET /readyz` (token-less, as kubelet sends it) → 403; `GET /status_check` (token-less) → 200. CI (`ct lint` / Kubeconform) validates rendering.