### PR TITLE
[BOYSCOUT]: Deliver probe token via X-Status-Token header

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.101
+version: 0.10.102
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
               protocol: TCP
           startupProbe:
             httpGet:
-              path: /readyz?token={{ .Values.global.statusCheckToken }}
+              path: /readyz
               port: server
               scheme: HTTP
               httpHeaders:
@@ -143,13 +143,17 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                # The kubelet probe delivers the shared secret via this header;
+                # an httpGet probe cannot send a ?token= query string.
+                - name: "X-Status-Token"
+                  value: {{ .Values.global.statusCheckToken }}
             periodSeconds: 10
             failureThreshold: 6
             timeoutSeconds: 5
           livenessProbe:
             failureThreshold: 10
             httpGet:
-              path: /livez?token={{ .Values.global.statusCheckToken }}
+              path: /livez
               port: server
               scheme: HTTP
               httpHeaders:
@@ -157,13 +161,17 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                # The kubelet probe delivers the shared secret via this header;
+                # an httpGet probe cannot send a ?token= query string.
+                - name: "X-Status-Token"
+                  value: {{ .Values.global.statusCheckToken }}
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /readyz?token={{ .Values.global.statusCheckToken }}
+              path: /readyz
               port: server
               scheme: HTTP
               httpHeaders:
@@ -171,6 +179,10 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                # The kubelet probe delivers the shared secret via this header;
+                # an httpGet probe cannot send a ?token= query string.
+                - name: "X-Status-Token"
+                  value: {{ .Values.global.statusCheckToken }}
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
## What

The `/livez`/`/readyz` server probes now pass the shared secret via an **`X-Status-Token` header** instead of a `?token=` query string. Drops the dead `?token=` from the probe paths. Bumps `datafold` chart `0.10.101`→`0.10.102`.

## Why

A kubelet `httpGet` probe **cannot deliver a query string** (the `?` is encoded into the path), so the `?token=` added in #350 never reached the server — `/readyz` returned 403 and the server pod crash-looped. kubelet *can* set custom `httpHeaders`, so the token goes in a header.

## Pairs with

datafold PR #13130 (server reads `X-Status-Token`, query fallback retained). **Ordering:** the server image with header support must be deployed to a cluster *before* that cluster's operator picks up this chart, or the probes 403 until both are present. Until then, clusters should stay on a pre-#350 operator (staging is pinned to `1.3.3`).

## Validation

Confirmed on a staging pod: `/livez` returns 200 and `/readyz` returns 200 for a token-carrying request once the server reads the header. CI (`ct lint` / Kubeconform) validates rendering.