### PR TITLE
[BOYSCOUT]: Pass statusCheckToken to server as STATUS_CHECK_TOKEN env

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.102
+version: 0.10.103
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             {{- end }}
           env:
             {{ include "datafold.env" . | nindent 12 }}
+            - name: STATUS_CHECK_TOKEN
+              value: {{ .Values.global.statusCheckToken | quote }}
             - name: DATAFOLD_FRESHPAINT_FRONTEND_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

Expose the status-check token to the datafold server container via a
`STATUS_CHECK_TOKEN` environment variable, sourced from
`global.statusCheckToken`.

## Why

The kubelet probes already deliver the shared token to the server through
the `X-Status-Token` httpHeader on the `/livez` and `/readyz` probes. With
this change the server can read the same token from `STATUS_CHECK_TOKEN`
and validate the probe header against it, so the status endpoints stay
safe-if-exposed in-process.

This pairs with a datafold server change that performs the header check.

## Changes

- server Deployment: add `STATUS_CHECK_TOKEN` env (value from
  `global.statusCheckToken`); probe `X-Status-Token` headers unchanged.
- Bump `charts/datafold` version 0.10.102 -> 0.10.103.

## Validation

`helm template` of the server Deployment with
`--set global.statusCheckToken=test123` renders `STATUS_CHECK_TOKEN: "test123"`
and all three probes carry `X-Status-Token: test123`.
---
## Related — `statusCheckToken` rollout (Option A: typed field)
One change set; all pieces are fail-open / self-consistent, so they merge & deploy in any order (the gate only activates once the server build + a token are both present on a cluster):
- **datafold/datafold-operator#123** — typed `Spec.Global.StatusCheckToken` field (+ emits it into the Helm `global` values)
- **datafold/helm-charts#356** — CRD schema so `spec.global.statusCheckToken` is accepted (not pruned)
- **datafold/helm-charts#355** — passes it to the server as `STATUS_CHECK_TOKEN` env
- **datafold/datafold#13136** — server validates the `X-Status-Token` probe header against it (fail-open when unset)
- **terraform-aws/azure/google-datafold #90 / #28 / #44** — generate a per-cluster token (customer self-hosted)
- **datafold/cloud-infra#1330** — set the token on Datafold-owned cluster seeds (typed `spec.global`)