### PR TITLE
[BOYSCOUT]: Add statusCheckToken to DatafoldApplication CRD global

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.115
+version: 0.1.117
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/templates/crds.yaml
+++ b/charts/datafold-manager/templates/crds.yaml
@@ -4030,6 +4030,13 @@ spec:
                     description: ShellRepository specifies the Docker repository for
                       shell images
                     type: string
+                  statusCheckToken:
+                    description: |-
+                      StatusCheckToken is the shared secret the server's /livez and /readyz probe
+                      endpoints validate (delivered by the kubelet via the X-Status-Token header).
+                      When empty the probes fail open. Deterrence-grade, not a hard boundary; the
+                      real perimeter is the nginx 404 + NetworkPolicy.
+                    type: string
                   storageClass:
                     description: StorageClass specifies the storage class to use for
                       persistent volumes


### PR DESCRIPTION
## What

Add `statusCheckToken` as a typed property under `spec.global` in the `datafold-manager` chart's DatafoldApplication CRD. Bumps the manager chart version.

## Why

The server `/livez`+`/readyz` probe gate reads `STATUS_CHECK_TOKEN` (chart `global.statusCheckToken`). The operator now emits this from a typed `Spec.Global.StatusCheckToken` field (datafold-operator #123). Since `spec.global` is a typed object, the CRD must declare `statusCheckToken` or it would be pruned on apply. This lets it be set cleanly via `spec.global.statusCheckToken` instead of `rawValues.global`.

Pairs with datafold-operator #123. Generated from the operator's CRD.
---
## Related — `statusCheckToken` rollout (Option A: typed field)
One change set; all pieces are fail-open / self-consistent, so they merge & deploy in any order (the gate only activates once the server build + a token are both present on a cluster):
- **datafold/datafold-operator#123** — typed `Spec.Global.StatusCheckToken` field (+ emits it into the Helm `global` values)
- **datafold/helm-charts#356** — CRD schema so `spec.global.statusCheckToken` is accepted (not pruned)
- **datafold/helm-charts#355** — passes it to the server as `STATUS_CHECK_TOKEN` env
- **datafold/datafold#13136** — server validates the `X-Status-Token` probe header against it (fail-open when unset)
- **terraform-aws/azure/google-datafold #90 / #28 / #44** — generate a per-cluster token (customer self-hosted)
- **datafold/cloud-infra#1330** — set the token on Datafold-owned cluster seeds (typed `spec.global`)