### PR TITLE
[BOYSCOUT]: Wire statusCheckToken end-to-end (server env + CRD field)

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.115
+version: 0.1.116
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/templates/crds.yaml
+++ b/charts/datafold-manager/templates/crds.yaml
@@ -4030,6 +4030,13 @@ spec:
                     description: ShellRepository specifies the Docker repository for
                       shell images
                     type: string
+                  statusCheckToken:
+                    description: |-
+                      StatusCheckToken is the shared secret the server's /livez and /readyz probe
+                      endpoints validate (delivered by the kubelet via the X-Status-Token header).
+                      When empty the probes fail open. Deterrence-grade, not a hard boundary; the
+                      real perimeter is the nginx 404 + NetworkPolicy.
+                    type: string
                   storageClass:
                     description: StorageClass specifies the storage class to use for
                       persistent volumes

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.3.4"
+    tag: "1.4.1"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.102
+version: 0.10.103
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             {{- end }}
           env:
             {{ include "datafold.env" . | nindent 12 }}
+            - name: STATUS_CHECK_TOKEN
+              value: {{ .Values.global.statusCheckToken | quote }}
             - name: DATAFOLD_FRESHPAINT_FRONTEND_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

One PR for both helm-charts halves of the typed `statusCheckToken` probe gate, so it deploys as a single operator re-vendor (supersedes #355 + #356):

- **datafold chart** — server container gets a `STATUS_CHECK_TOKEN` env from `global.statusCheckToken` (validates the `X-Status-Token` header the kubelet sends on `/livez`+`/readyz`).
- **datafold-manager CRD** — declares the typed `spec.global.statusCheckToken` so it isn't pruned (the operator emits it; `global` is a typed object).

## Versions (for the operator subrepo deploy)

| Chart / value | → |
|---|---|
| `charts/datafold/Chart.yaml` | `0.10.103` |
| `charts/datafold-manager/Chart.yaml` | `0.1.116` |
| `charts/datafold-manager/values.yaml` `operator.image.tag` | `1.4.1` |

`1.4.1` = the next operator release: `1.4.0` already carries the Go field (datafold-operator#123) but vendors the old chart, so it neither accepts nor passes the token; re-vendoring this PR produces `1.4.1` which completes it.

## Deploy

1. Merge this → 2. re-vendor helm-charts into datafold-operator (`fix:` → publishes `1.4.1`) → 3. `update-df-mgr` (default `operator.image.tag` is now `1.4.1`).

## Pairs with

- **datafold-operator#123** — typed `Spec.Global.StatusCheckToken` (merged, in `1.4.0`)
- **datafold/datafold#13136** — server validates the header (fail-open when unset)
- **terraform aws #90 / azure #28 / google #44**, **cloud-infra#1330** — set the per-cluster token

Validated: `helm template` renders the server `STATUS_CHECK_TOKEN` env and the CRD `spec.global.statusCheckToken` property.