### PR TITLE
[BOYSCOUT]: Raise readiness probe successThreshold to 3

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.116
+version: 0.1.117
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.4.1"
+    tag: "1.4.3"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.103
+version: 0.10.104
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -186,7 +186,7 @@ spec:
                 - name: "X-Status-Token"
                   value: {{ .Values.global.statusCheckToken }}
             periodSeconds: 10
-            successThreshold: 1
+            successThreshold: 3
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## Summary

- Raises `successThreshold` on the server readiness probe from 1 → 3
- Requires three consecutive passing `/readyz` checks (30 s) before kube-proxy re-adds a pod to Service endpoints
- Prevents a pod in a crash/kill-loop from oscillating back into the load balancer after a single lucky probe hit during a brief worker-respawn window
- Liveness probe is unchanged — Kubernetes requires `successThreshold: 1` for liveness probes

## Test plan

- [ ] Deploy to a test/staging environment and verify a newly-started pod takes ~30 s to become Ready (3 × 10 s period) rather than 10 s
- [ ] Verify that a pod that was previously NotReady does not receive traffic until it passes three consecutive readiness checks
- [ ] Confirm no impact to normal rolling-update behaviour (pods just take slightly longer to enter rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)