### PR TITLE
Fail open on unset statusCheckToken; drop magic_token default

### DIFF
--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.117
+version: 0.1.118
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.4.3"
+    tag: "1.4.4"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.104
+version: 0.10.105
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -62,8 +62,12 @@ spec:
             {{- end }}
           env:
             {{ include "datafold.env" . | nindent 12 }}
+            {{- if .Values.global.statusCheckToken }}
+            # Probe-gate token (server validates X-Status-Token). Omitted when
+            # unset so /livez+/readyz fail open instead of enforcing a default.
             - name: STATUS_CHECK_TOKEN
               value: {{ .Values.global.statusCheckToken | quote }}
+            {{- end }}
             - name: DATAFOLD_FRESHPAINT_FRONTEND_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -145,10 +149,13 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                {{- if .Values.global.statusCheckToken }}
                 # The kubelet probe delivers the shared secret via this header;
-                # an httpGet probe cannot send a ?token= query string.
+                # an httpGet probe cannot send a ?token= query string. Omitted
+                # when no token is configured so the probes fail open.
                 - name: "X-Status-Token"
                   value: {{ .Values.global.statusCheckToken }}
+                {{- end }}
             periodSeconds: 10
             failureThreshold: 6
             timeoutSeconds: 5
@@ -163,10 +170,13 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                {{- if .Values.global.statusCheckToken }}
                 # The kubelet probe delivers the shared secret via this header;
-                # an httpGet probe cannot send a ?token= query string.
+                # an httpGet probe cannot send a ?token= query string. Omitted
+                # when no token is configured so the probes fail open.
                 - name: "X-Status-Token"
                   value: {{ .Values.global.statusCheckToken }}
+                {{- end }}
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
@@ -181,10 +191,13 @@ spec:
                   value: {{ .Values.global.serverName }}
                 - name: "X-Forwarded-Proto"
                   value: https
+                {{- if .Values.global.statusCheckToken }}
                 # The kubelet probe delivers the shared secret via this header;
-                # an httpGet probe cannot send a ?token= query string.
+                # an httpGet probe cannot send a ?token= query string. Omitted
+                # when no token is configured so the probes fail open.
                 - name: "X-Status-Token"
                   value: {{ .Values.global.statusCheckToken }}
+                {{- end }}
             periodSeconds: 10
             successThreshold: 3
             timeoutSeconds: 5

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -15,7 +15,7 @@ global:
   secondaryDeployment: false
   cloudProvider: ""
   authMethod: "password"
-  statusCheckToken: "magic_token"
+  statusCheckToken: ""
   datafoldRepository: "us-docker.pkg.dev/datadiff-mm/datafold"
   datafoldImage: "server"
   shellRepository: "us-docker.pkg.dev/datadiff-mm/datafold"


### PR DESCRIPTION
## What

- Default `global.statusCheckToken` → `""` (was `"magic_token"`).
- Omit the `STATUS_CHECK_TOKEN` env var **and** the probe `X-Status-Token` headers when the token is unset (conditional template).

## Why

The server probe-token gate (datafold#13136) treats empty `STATUS_CHECK_TOKEN` as unset → **fail open**. The `magic_token` default broke that intent: once #13136 ships, every un-overridden cluster would (a) enforce a **publicly-known** token baked into this public repo (zero security), and (b) risk a readiness **outage** if the `X-Status-Token` header were ever not delivered. Defaulting to unset + omitting the wiring makes probes genuinely fail open until a real per-cluster token is provisioned (cloud-infra#1330 / terraform token generators).

## Verified (helm template)

- Token unset → no `STATUS_CHECK_TOKEN` env, no `X-Status-Token` headers.
- Token set → env + all 3 probe headers carry the value.

Includes the 4 version bumps: datafold chart `0.10.105`, manager chart `0.1.118`, `operator.image.tag` → `1.4.4`.