### PR TITLE
[ENG-4240]: repo-mirror StatefulSet uses OnDelete update strategy

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.105
+version: 0.10.106
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-repo-mirror/templates/statefulset.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
   serviceName: {{ include "worker-repo-mirror.serviceName" . }}
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- include "worker-repo-mirror.selectorLabels" . | nindent 6 }}

--- a/charts/datafold/charts/worker-repo-mirror/values.yaml
+++ b/charts/datafold/charts/worker-repo-mirror/values.yaml
@@ -1,5 +1,14 @@
 replicaCount: 1
 
+# OnDelete decouples the mirror from the app deploy cadence: an image-tag bump
+# does NOT roll this pod, so it keeps its warm /repos PVC and keeps
+# incremental-fetching across every app deploy. Cycle it deliberately (delete
+# the pod) only when the mirror worker code itself changes. RollingUpdate (the
+# k8s default) would bounce the single replica on every deploy — opening a
+# `no_mirror` gap for consumers and SIGKILL-ing in-flight fetches.
+updateStrategy:
+  type: OnDelete
+
 image:
   pullPolicy: IfNotPresent
   tag: ""


### PR DESCRIPTION
## Summary

Switch the `worker-repo-mirror` StatefulSet from the default `RollingUpdate` to `OnDelete`.

## Why

The mirror is a **single-replica** StatefulSet on an **RWO PVC** — a warm bare-repo cache that's built once and kept current by incremental `git fetch`. Because it shares the monolith `server` image, `RollingUpdate` bounces it on **every app deploy**. Observed in saas: ~9 mirror-pod restarts in 8h under normal deploy cadence. Each restart:

- opens a `no_mirror` gap — consumers' 1s TCP probe to the daemon fails → silent fallback to a direct upstream clone (~5× slower: ~85s vs ~16s on the repo measured), and
- SIGKILLs in-flight `git clone --mirror` / `fetch` mid-transfer → the `fatal: the remote end hung up unexpectedly` errors on the mirror worker.

The bare cache itself survives restarts (it's on the PVC), so this is an availability + wasted-work problem, not data loss.

`OnDelete` decouples the mirror's lifecycle from the app deploy cadence: an image-tag bump no longer rolls the pod, so it keeps its warm `/repos` PVC and keeps fetching across deploys. The pod is cycled **deliberately** (delete it) only when the mirror worker code actually changes.

## Why default it (not per-deployment opt-in)

Every deployment's mirror has the same single-replica + RWO shape, so `OnDelete` is universally correct for this chart. Consumers already tolerate a missing/stale mirror (silent direct-clone fallback + per-clone upstream top-up fetch), so a bare that's stale-by-a-cycle is safe. Low-risk to run slightly older code on this pod: it only runs `git daemon` + `ensure_repo_mirrored_activity`, no user-facing surface, no auth beyond a short-lived GH token mint.

## Operational note

After this ships, **mirror code changes require a manual pod cycle** to take effect:
```
kubectl delete pod datafold-worker-repo-mirror-0 -n <ns>
```
(The PVC re-attaches and the warm cache is preserved.)

## Changes

- `worker-repo-mirror/templates/statefulset.yaml` — add `updateStrategy.type` (one line)
- `worker-repo-mirror/values.yaml` — default `updateStrategy.type: OnDelete` + rationale comment
- `datafold/Chart.yaml` — version bump `0.10.105` → `0.10.106` for operator pickup

## Verification

`helm template` renders exactly one `updateStrategy: OnDelete`, on the mirror StatefulSet; no other workload's spec changes.
