### PR TITLE
[ENG-4140]: Scrape worker_type + poller_type on temporal workers

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.109
+version: 0.10.110
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/deployment.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/deployment.yaml
@@ -27,7 +27,13 @@ spec:
         #
         # 1. include_labels — allowlist of the only scraped SDK labels that any
         #    Datadog monitor or the temporal dashboard actually queries: task_queue,
-        #    workflow_type, activity_type. Every other scraped label (operation,
+        #    workflow_type, activity_type, plus worker_type + poller_type (ENG-4140:
+        #    the operator dashboard's worker-capacity section splits slots by
+        #    worker_type and pollers by poller_type; without these, prod series land
+        #    as worker_type:N/A / poller_type:N/A — only dev stacks that scrape all
+        #    labels populated them). Both are low-cardinality (worker_type has 3
+        #    values: activity/workflow/localactivity; poller_type 2), so the added
+        #    custom-metric volume is small. Every other scraped label (operation,
         #    namespace, service_name, version, ...) is dropped.
         # 2. tag_by_endpoint=false — drops the `endpoint` tag
         #    (http://<pod-ip>:9090/metrics), which is effectively per-pod cardinality.
@@ -63,7 +69,9 @@ spec:
                 "include_labels": [
                   "task_queue",
                   "workflow_type",
-                  "activity_type"
+                  "activity_type",
+                  "worker_type",
+                  "poller_type"
                 ],
                 "collect_histogram_buckets": true,
                 "histogram_buckets_as_distributions": true,


### PR DESCRIPTION
## What
Add `worker_type` and `poller_type` to the Datadog OpenMetrics `include_labels` allowlist for the temporal-worker scrape (`charts/datafold/charts/worker-temporal/templates/deployment.yaml`).

## Why
The Thunderbolt operator dashboard (`tcw-ezh-m2h`) gained a **Worker capacity & pollers** section (ENG-4140). We want slots split by `worker_type` (activity vs workflow) and pollers by `poller_type`. The Temporal SDK already emits both labels at `:9090/metrics`, but the prod scrape's `include_labels` kept only `task_queue` / `workflow_type` / `activity_type` — so every prod `temporal_worker.*` series lands as `worker_type:N/A` / `poller_type:N/A`. (Only dev/local stacks, whose `deploy/dev.yml` scrape uses `metrics: [".*"]` with no allowlist, populated them — which is why the DD facet picker shows the values.)

## Impact
- Both labels are low-cardinality (`worker_type`: activity/workflow/localactivity = 3; `poller_type` = 2), so the added custom-metric volume is small.
- They're already in the Datadog **indexed-tag allowlist** for these metrics, so **no DD-side config change** is needed — once this deploys, prod series carry the values and the dashboard panels can split by them.
- `exclude_metrics_by_labels` (the sticky-queue value drop) and all other scrape settings are unchanged.

## After deploy
The operator dashboard's slot/poller panels (currently queue-level aggregates) can be switched to `by {worker_type}` / `by {poller_type}` (separate change in the datafold repo).