### PR TITLE
[ENG-4128]: Add minimal in-cluster Prometheus subchart for KEDA triggers

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.111
+version: 0.10.112
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 
@@ -157,3 +157,7 @@ dependencies:
     version: "*.*.*"
     repository: file://charts/datadog
     condition: global.datadog.install
+  - name: prometheus
+    version: "*.*.*"
+    repository: file://charts/prometheus
+    condition: prometheus.install

--- a/charts/datafold/charts/prometheus/Chart.yaml
+++ b/charts/datafold/charts/prometheus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: prometheus
+description: Minimal in-cluster Prometheus backing KEDA prometheus triggers (scaling control loop, not an observability stack)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/datafold/charts/prometheus/templates/_helpers.tpl
+++ b/charts/datafold/charts/prometheus/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Service Account name
+*/}}
+{{- define "prometheus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- include "prometheus.name" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus.labels" -}}
+helm.sh/chart: {{ include "prometheus.chart" . }}
+app.kubernetes.io/component: {{ include "prometheus.name" . }}
+{{ include "prometheus.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{ include "datafold.labels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus.name" . }}
+app.kubernetes.io/part-of: datafold
+{{- end }}

--- a/charts/datafold/charts/prometheus/templates/configmap.yaml
+++ b/charts/datafold/charts/prometheus/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prometheus.fullname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: {{ .Values.scrapeInterval }}
+    scrape_configs:
+      - job_name: datafold-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_part_of]
+            regex: datafold
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            regex: metrics
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_phase]
+            regex: Running
+            action: keep
+          # The Temporal SDK metrics carry no pod identity; without this label,
+          # same-named series from different pods collapse and sum() undercounts.
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            target_label: worker
+          # Not `namespace`: the Temporal SDK already emits a `namespace` label
+          # (the Temporal logical namespace) that queries must see unmangled.
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: kubernetes_namespace
+      {{- with .Values.extraScrapeConfigs }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/datafold/charts/prometheus/templates/deployment.yaml
+++ b/charts/datafold/charts/prometheus/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus.fullname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "prometheus.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "prometheus.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "prometheus.serviceAccountName" . }}
+      securityContext:
+        runAsUser: 65534
+        runAsNonRoot: true
+        fsGroup: 65534
+      containers:
+        - name: prometheus
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: False
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time={{ .Values.retentionTime }}
+            - --storage.tsdb.retention.size={{ .Values.retentionSize }}
+            - --web.listen-address=:{{ .Values.port }}
+          ports:
+            - name: web
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: web
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: web
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "prometheus.fullname" . }}
+        - name: data
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/datafold/charts/prometheus/templates/rbac.yaml
+++ b/charts/datafold/charts/prometheus/templates/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus.serviceAccountName" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "prometheus.fullname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "prometheus.fullname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prometheus.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prometheus.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/datafold/charts/prometheus/templates/service.yaml
+++ b/charts/datafold/charts/prometheus/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus.fullname" . }}
+  labels:
+    {{- include "prometheus.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: web
+      port: {{ .Values.port }}
+      targetPort: web
+      protocol: TCP
+  selector:
+    {{- include "prometheus.selectorLabels" . | nindent 4 }}

--- a/charts/datafold/charts/prometheus/values.yaml
+++ b/charts/datafold/charts/prometheus/values.yaml
@@ -1,0 +1,41 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: prom/prometheus
+  tag: v3.5.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Scaling control-loop backend: short retention, no persistence (emptyDir).
+# KEDA triggers only query the last few minutes; losing history on restart is acceptable.
+retentionTime: 24h
+retentionSize: 2GB
+
+scrapeInterval: 30s
+
+port: 9090
+
+# Additional scrape_configs appended verbatim to prometheus.yml.
+extraScrapeConfigs: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    memory: 512Mi
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -362,6 +362,10 @@ worker-thunderbolt:
 worker-repo-mirror:
   install: false
 
+# Minimal in-cluster Prometheus backing KEDA prometheusTriggers (see docs/keda.md).
+prometheus:
+  install: false
+
 worker:
   install: true
   replicaCount: 1

--- a/docs/keda.md
+++ b/docs/keda.md
@@ -196,6 +196,16 @@ workers' `:9090` metrics endpoint. Not supported on workers polling multiple
 `taskQueues` — the composite `scalingModifiers` formula those use would
 silently ignore extra triggers, so the template fails fast instead.
 
+The chart ships an optional minimal Prometheus for exactly this. Set
+`prometheus.install: true` and it deploys a single-replica, emptyDir-backed
+instance (24h retention — a scaling control loop, not an observability stack)
+that scrapes every datafold pod exposing a container port named `metrics` in
+the release namespace, preserving per-pod identity via a `pod` label (the
+Temporal SDK metrics carry none, so unlabeled aggregation would undercount).
+It serves queries at `http://<release>-prometheus:9090` — with the standard
+release name that is `http://datafold-prometheus:9090`, matching the
+`serverAddress` in the example above.
+
 ### Per-worker overrides
 
 Override the defaults for individual worker types in your `values.yaml`. For

--- a/docs/keda.md
+++ b/docs/keda.md
@@ -205,9 +205,11 @@ instance (24h retention — a scaling control loop, not an observability stack)
 that scrapes every datafold pod exposing a container port named `metrics` in
 the release namespace, preserving per-pod identity via a `pod` label (the
 Temporal SDK metrics carry none, so unlabeled aggregation would undercount).
-It serves queries at `http://<release>-prometheus:9090` — with the standard
-release name that is `http://datafold-prometheus:9090`, matching the
-`serverAddress` in the example above.
+It serves queries at
+`http://<release>-prometheus.<namespace>.svc.cluster.local:9090` — with the
+standard release name in e.g. the `saas` namespace that is
+`http://datafold-prometheus.saas.svc.cluster.local:9090`, the form the
+`serverAddress` in the example above expects.
 
 ### Per-worker overrides
 


### PR DESCRIPTION
## Why

Stacked on #365 (review that first). The `keda.prometheusTriggers` knob needs a Prometheus to query — and we deliberately keep Datadog out of the scaling control loop. This adds the smallest thing that serves KEDA: single replica, emptyDir, 24h/2GB retention. Not an observability stack — Datadog remains the analysis surface.

## What

New optional subchart `charts/datafold/charts/prometheus/` gated by `prometheus.install` (default **false** — rendered output is byte-identical to the base branch when unset).

- Scrapes pods in the release namespace with `app.kubernetes.io/part-of=datafold` + container port named `metrics` (the workers' Temporal SDK `:9090` endpoint), 30s interval
- **Per-pod `pod` relabel is load-bearing**: the SDK metrics carry no pod identity, so unlabeled `sum()` collapses same-named series across pods and undercounts slots — the exact defect our DD ingestion of these metrics has today
- k8s namespace lands in `kubernetes_namespace` (not `namespace`, which the Temporal SDK already uses for its logical namespace — collision would mangle queries)
- Namespaced RBAC only (Role: pods get/list/watch); runs as nobody; `Recreate` strategy (single emptyDir instance)
- Service `<release>-prometheus:9090` — with the standard release name, exactly the `http://datafold-prometheus:9090` serverAddress documented in #365's `prometheusTriggers` example
- `docs/keda.md` extended

## Validation

- Default render byte-identical to base branch (full-manifest diff, dev/ values)
- `install=true` renders SA/Role/RoleBinding/ConfigMap/Deployment/Service correctly
- Rendered `prometheus.yml` passes `promtool check config` (v3.5.0)
- `helm lint` clean
- Live smoke on the testing cluster planned (apply rendered docs → verify worker targets + slots query with pod labels → delete)

## Notes

- Operator CRD flag to enable this per-deployment comes with the rollout wiring (the operator currently has no passthrough for non-component top-level values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)