### PR TITLE
[ENG-4128]: Keep the prometheus subchart out of kopf's version scan

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.112
+version: 0.10.113
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/prometheus/templates/_helpers.tpl
+++ b/charts/datafold/charts/prometheus/templates/_helpers.tpl
@@ -55,9 +55,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels.
+
+Deliberately NO `app.kubernetes.io/part-of: datafold` here: kopf-datafold's
+upgrade manager treats every deployment carrying that label as a datafold-app
+component and reads its image tag as "the running datafold version". A
+third-party image tag (prom/prometheus:vX) in that set makes kopf conclude an
+upgrade never completed and re-roll every worker on each timer tick. Same
+convention as the memgraph / redis / clickhouse subcharts.
 */}}
 {{- define "prometheus.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "prometheus.name" . }}
-app.kubernetes.io/part-of: datafold
 {{- end }}


### PR DESCRIPTION
## Why

**Blocks the saas prometheus rollout.** kopf-datafold's upgrade manager determines "the running datafold version" by reading the image tag of **every deployment labeled `app.kubernetes.io/part-of: datafold`**. The prometheus subchart (merged in #365/#366) copied the worker chart's label helper — including that label — with image `prom/prometheus:v3.5.0`. kopf then sees the version set `{'v3.5.0', '<app version>'}`, logs `A previous upgrade did not complete`, and launches a full upgrade rollout **every timer tick (~2 min), forever** — scaling every worker deployment down and back up each cycle.

Observed live on testing within minutes of installing the subchart (kopf logs: `Resource datafold-prometheus is at v3.5.0` + perpetual `Rollout complete in ~65s`). Removing the label from the live deployment stopped the loop on the next scan.

## What

- Drop `app.kubernetes.io/part-of: datafold` from `prometheus.selectorLabels` — matching the **memgraph / redis / clickhouse convention**: third-party-image components stay out of kopf's version scan. Comment added explaining the constraint so the next foreign-image subchart doesn't repeat this.
- Worker-pod scraping unchanged — the scrape config keys on the *worker pods'* labels, which keep `part-of`.

## Rollout caveat

The Deployment selector is immutable, so the one existing install (testing) rolls via component disable → enable in the CR, not helm-patch. saas never installed prometheus — clean first install once this lands.

## Follow-up (separate)

kopf could defensively filter non-datafold image registries in its version scan — ticket-able hardening, not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)