### PR TITLE
[ENG-4128]: Document and enforce the queueTypes/minReplicas pairing rule

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.113
+version: 0.10.114
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/scaledobject.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/scaledobject.yaml
@@ -4,6 +4,9 @@
 {{- if and $multi .Values.keda.prometheusTriggers }}
 {{- fail "keda.prometheusTriggers cannot be combined with multiple taskQueues: the scalingModifiers composite formula would silently ignore them" }}
 {{- end }}
+{{- if and (eq (int .Values.keda.minReplicas) 0) (eq .Values.keda.queueTypes "activity") }}
+{{- fail "keda.minReplicas=0 with queueTypes=\"activity\" deadlocks: a fresh workflow's first task is a workflow task, which this configuration ignores for both metric and activation, so no pod ever wakes to serve it. Set minReplicas >= 1 or include \"workflow\" in queueTypes." }}
+{{- end }}
 {{- $targetQueueSize := .Values.keda.targetQueueSize | default .Values.temporal.maxConcurrency }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -75,6 +75,16 @@ keda:
   # or both comma-separated. Empty uses the KEDA scaler's default, which is version-dependent —
   # pin explicitly when the distinction matters (e.g. "activity" for workers whose scaling is
   # about activity slots, not ms-fast workflow tasks).
+  #
+  # PAIRING RULE with minReplicas (verified live on KEDA 2.19, ENG-4128):
+  #   - minReplicas >= 1  → pin "activity". The cleanest sizing signal: only activities can
+  #     accumulate (workflow tasks drain in ms whenever a poller exists), and workflow-task
+  #     orphans (the dominant ENG-4128 leak class) can never pollute the metric.
+  #   - minReplicas == 0  → MUST include "workflow" (e.g. "workflow,activity"). A fresh
+  #     workflow's first task is a workflow task; pinned to "activity" the scaler ignores it
+  #     for both metric and activation, no pod ever wakes, and the workflow deadlocks at
+  #     zero pollers. The template fails fast on the deadlocking combination.
+  # Prefer minReplicas >= 1: no wake latency, no deadlock class, no orphan exposure.
   queueTypes: ""
   scaleDown:
     stabilizationWindowSeconds: 300

--- a/docs/keda.md
+++ b/docs/keda.md
@@ -159,7 +159,7 @@ keda:
 | `cooldownPeriod` | `300` | Seconds after the queue empties before scaling to zero begins. |
 | `targetQueueSize` | `""` | Queued tasks per pod the HPA targets: `desired = ceil(backlog / targetQueueSize)`. Empty inherits `temporal.maxConcurrency` — fine for fast tasks, but for long-running activities even a short queue means a long wait, so set it lower (e.g. `"1"`–`"2"`). |
 | `activationTargetQueueSize` | `"0"` | Queue depth that must be exceeded to scale from 0 → 1. `"0"` means any task activates the worker. |
-| `queueTypes` | `""` | Which Temporal task types count toward the backlog (`"activity"`, `"workflow"`, or both comma-separated). Empty uses the KEDA scaler default, which is version-dependent — pin it when the distinction matters. |
+| `queueTypes` | `""` | Which Temporal task types count toward the backlog (`"activity"`, `"workflow"`, or both comma-separated). Empty uses the KEDA scaler default, which is version-dependent — pin it when the distinction matters. **Pairing rule:** with `minReplicas: 0` this must include `workflow` — see below. |
 | `scaleDown.stabilizationWindowSeconds` | `300` | HPA stabilization window — prevents rapid scale-down oscillation. |
 | `scaleDown.policies` | `[]` | HPA v2 scale-down rate policies, passed through verbatim (e.g. `{type: Pods, value: 1, periodSeconds: 600}` sheds at most one pod per 10 minutes). |
 | `fallback` | `{}` | KEDA `spec.fallback` (`failureThreshold` + `replicas`): hold a fixed replica count after a scaler errors repeatedly. Applies to `AverageValue` metrics such as `prometheusTriggers`. |
@@ -169,6 +169,28 @@ keda:
 > **Scale-out target.** `keda.targetQueueSize` controls how aggressively a
 > worker scales out. When left empty it inherits `temporal.maxConcurrency` —
 > the number of concurrent tasks one replica handles — which suits fast tasks.
+
+### queueTypes and scale-to-zero (the pairing rule)
+
+A fresh workflow's **first task is a workflow task**. A worker at zero replicas
+has zero pollers, so that task sits in the workflow backlog — and a scaler
+pinned to `queueTypes: "activity"` ignores it for **both** the metric and
+activation (verified live on KEDA 2.19): no pod ever wakes, and the workflow
+deadlocks. Hence:
+
+- **`minReplicas >= 1` (recommended): pin `queueTypes: "activity"`.** The
+  always-on poller serves the ms-fast workflow tasks, and the scaling metric
+  stays purely activity-driven — the only task type that actually accumulates,
+  and immune to workflow-task orphan rows polluting the count.
+- **`minReplicas: 0`: include `workflow`** (e.g. `"workflow,activity"`). The
+  workflow term is ~0 whenever a pod exists (workflow tasks drain in
+  milliseconds), so it barely affects sizing — it exists to break the
+  wake-from-zero chicken-and-egg. Trade-off: workflow-task orphans (if the
+  upstream matching leak ever recurs) would re-enter the metric and can
+  prevent scale-to-zero.
+
+The template **fails fast** on the deadlocking combination
+(`minReplicas: 0` + `queueTypes: "activity"`).
 
 ### Prometheus triggers (in-flight-slots hold)
 


### PR DESCRIPTION
## Why

Verified live on testing (KEDA 2.19), after the kopf re-roll loop (#367) stopped masking it: **`minReplicas: 0` + `queueTypes: "activity"` deadlocks fresh workflows.** A workflow's first task is a *workflow* task; pinned to `activity`, the scaler ignores it for both the metric and activation, so no pod ever wakes to serve it. Experiment: goal at 0 pods sat 5+ minutes with workflow backlog = 1 / `ACTIVE=False`; switching to `"workflow,activity"` woke the fleet **within one second** of the ScaledObject update.

## What

- **Pairing rule documented** (values.yaml + docs/keda.md):
  - `minReplicas >= 1` (recommended) → pin `"activity"`: purest sizing signal (only activities accumulate; workflow tasks drain in ms), immune to workflow-task orphan rows (the dominant ENG-4128 leak class).
  - `minReplicas: 0` → must include `"workflow"`: the workflow term is ~0 whenever a pod exists, so it barely affects sizing — it exists to break the wake-from-zero chicken-and-egg. Trade-off documented (orphan exposure could prevent scale-to-zero).
- **Fail-fast guard** in the template on the deadlocking combination (same pattern as the multi-queue prometheusTriggers guard). Render-verified: fires on the bad combo, silent on `min>=1+activity`, `min=0+workflow,activity`, and all defaults.

No behavior change for any existing deployment (none uses the deadlocking combo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)