### PR TITLE
[ENG-4128]: Bake the thunderbolt KEDA calibration into chart defaults

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.114
+version: 0.10.115
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.113
+version: 0.10.114
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/scaledobject.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/scaledobject.yaml
@@ -4,6 +4,9 @@
 {{- if and $multi .Values.keda.prometheusTriggers }}
 {{- fail "keda.prometheusTriggers cannot be combined with multiple taskQueues: the scalingModifiers composite formula would silently ignore them" }}
 {{- end }}
+{{- if and (eq (int .Values.keda.minReplicas) 0) (eq .Values.keda.queueTypes "activity") }}
+{{- fail "keda.minReplicas=0 with queueTypes=\"activity\" deadlocks: a fresh workflow's first task is a workflow task, which this configuration ignores for both metric and activation, so no pod ever wakes to serve it. Set minReplicas >= 1 or include \"workflow\" in queueTypes." }}
+{{- end }}
 {{- $targetQueueSize := .Values.keda.targetQueueSize | default .Values.temporal.maxConcurrency }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -52,6 +52,9 @@ temporal:
   # Comma-separated list or the special value "all".
   taskQueues: "none"
   # maxConcurrency sets TEMPORAL_MAX_CONCURRENCY — the number of concurrent activity/workflow tasks.
+  # Changing it for a worker also changes its scaling math: the default keda.targetQueueSize
+  # inherits it, and any slots-hold prometheusTriggers threshold must stay BELOW it so the
+  # hold never under-counts busy pods (see worker-thunderbolt in the parent values.yaml).
   maxConcurrency: "5"
   # workerPoolType sets DATAFOLD_WORKER_POOL_TYPE. Leave empty for the default pool type.
   workerPoolType: "thread"

--- a/charts/datafold/charts/worker-temporal/values.yaml
+++ b/charts/datafold/charts/worker-temporal/values.yaml
@@ -75,6 +75,16 @@ keda:
   # or both comma-separated. Empty uses the KEDA scaler's default, which is version-dependent —
   # pin explicitly when the distinction matters (e.g. "activity" for workers whose scaling is
   # about activity slots, not ms-fast workflow tasks).
+  #
+  # PAIRING RULE with minReplicas (verified live on KEDA 2.19, ENG-4128):
+  #   - minReplicas >= 1  → pin "activity". The cleanest sizing signal: only activities can
+  #     accumulate (workflow tasks drain in ms whenever a poller exists), and workflow-task
+  #     orphans (the dominant ENG-4128 leak class) can never pollute the metric.
+  #   - minReplicas == 0  → MUST include "workflow" (e.g. "workflow,activity"). A fresh
+  #     workflow's first task is a workflow task; pinned to "activity" the scaler ignores it
+  #     for both metric and activation, no pod ever wakes, and the workflow deadlocks at
+  #     zero pollers. The template fails fast on the deadlocking combination.
+  # Prefer minReplicas >= 1: no wake latency, no deadlock class, no orphan exposure.
   queueTypes: ""
   scaleDown:
     stabilizationWindowSeconds: 300

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -341,10 +341,29 @@ worker-thunderbolt:
   terminationGracePeriodSeconds: "1800"
   temporal:
     taskQueues: "thunderbolt"
+    # The fleet-standard concurrency, stated explicitly: the keda calibration below is derived
+    # from it (targetQueueSize "2"; a slots-hold prometheusTrigger, wired per-deployment because
+    # its serverAddress is namespace-qualified, uses setpoint "6" = 75% of these slots).
+    maxConcurrency: "8"
     workerPoolType: "process"
     gracefulShutdownTimeout: "1800"
   keda:
-    minReplicas: 0
+    # Pairing rule (see worker-temporal values.yaml): with queueTypes pinned to "activity",
+    # minReplicas must be >= 1. Deployments raise it further (saas runs 4).
+    minReplicas: 1
+    # Long-running LLM activities (up to 2h30m): a queued task means a long wait, so scale up
+    # on any sustained queue. The old inherited default (targetQueueSize = maxConcurrency)
+    # implied a ~1.5h wait budget and never reacted (ENG-4128).
+    targetQueueSize: "2"
+    # Activity tasks are the only type that accumulates; workflow tasks drain in ms with a
+    # live poller, and workflow-task orphan rows can never pollute the metric.
+    queueTypes: "activity"
+    scaleDown:
+      stabilizationWindowSeconds: 1800
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 600
   # Thunderbolt agents run cross-DB replication (copy_table) into a scratch
   # dir under /data (REPLICATION_WORK_DIR=/data/replication). Without an
   # attached volume /data isn't writable and copy_table fails, so mount a

--- a/docs/keda.md
+++ b/docs/keda.md
@@ -159,7 +159,7 @@ keda:
 | `cooldownPeriod` | `300` | Seconds after the queue empties before scaling to zero begins. |
 | `targetQueueSize` | `""` | Queued tasks per pod the HPA targets: `desired = ceil(backlog / targetQueueSize)`. Empty inherits `temporal.maxConcurrency` — fine for fast tasks, but for long-running activities even a short queue means a long wait, so set it lower (e.g. `"1"`–`"2"`). |
 | `activationTargetQueueSize` | `"0"` | Queue depth that must be exceeded to scale from 0 → 1. `"0"` means any task activates the worker. |
-| `queueTypes` | `""` | Which Temporal task types count toward the backlog (`"activity"`, `"workflow"`, or both comma-separated). Empty uses the KEDA scaler default, which is version-dependent — pin it when the distinction matters. |
+| `queueTypes` | `""` | Which Temporal task types count toward the backlog (`"activity"`, `"workflow"`, or both comma-separated). Empty uses the KEDA scaler default, which is version-dependent — pin it when the distinction matters. **Pairing rule:** with `minReplicas: 0` this must include `workflow` — see below. |
 | `scaleDown.stabilizationWindowSeconds` | `300` | HPA stabilization window — prevents rapid scale-down oscillation. |
 | `scaleDown.policies` | `[]` | HPA v2 scale-down rate policies, passed through verbatim (e.g. `{type: Pods, value: 1, periodSeconds: 600}` sheds at most one pod per 10 minutes). |
 | `fallback` | `{}` | KEDA `spec.fallback` (`failureThreshold` + `replicas`): hold a fixed replica count after a scaler errors repeatedly. Applies to `AverageValue` metrics such as `prometheusTriggers`. |
@@ -169,6 +169,28 @@ keda:
 > **Scale-out target.** `keda.targetQueueSize` controls how aggressively a
 > worker scales out. When left empty it inherits `temporal.maxConcurrency` —
 > the number of concurrent tasks one replica handles — which suits fast tasks.
+
+### queueTypes and scale-to-zero (the pairing rule)
+
+A fresh workflow's **first task is a workflow task**. A worker at zero replicas
+has zero pollers, so that task sits in the workflow backlog — and a scaler
+pinned to `queueTypes: "activity"` ignores it for **both** the metric and
+activation (verified live on KEDA 2.19): no pod ever wakes, and the workflow
+deadlocks. Hence:
+
+- **`minReplicas >= 1` (recommended): pin `queueTypes: "activity"`.** The
+  always-on poller serves the ms-fast workflow tasks, and the scaling metric
+  stays purely activity-driven — the only task type that actually accumulates,
+  and immune to workflow-task orphan rows polluting the count.
+- **`minReplicas: 0`: include `workflow`** (e.g. `"workflow,activity"`). The
+  workflow term is ~0 whenever a pod exists (workflow tasks drain in
+  milliseconds), so it barely affects sizing — it exists to break the
+  wake-from-zero chicken-and-egg. Trade-off: workflow-task orphans (if the
+  upstream matching leak ever recurs) would re-enter the metric and can
+  prevent scale-to-zero.
+
+The template **fails fast** on the deadlocking combination
+(`minReplicas: 0` + `queueTypes: "activity"`).
 
 ### Prometheus triggers (in-flight-slots hold)
 


### PR DESCRIPTION
## Why

Two ENG-4128 follow-ups, folded into one PR (was stacked on #368, now collapsed):

1. **queueTypes/minReplicas pairing rule** — verified live on testing (KEDA 2.19): `minReplicas: 0` + `queueTypes: "activity"` deadlocks fresh workflows (a workflow's first task is a *workflow* task, which that config ignores for both metric and activation; a goal sat 5+ min at 0 pods until the config flipped, then woke <1s). Documented in values.yaml + docs/keda.md; template **fails fast** on the deadlocking combination.
2. **Thunderbolt calibration as chart defaults** — every deployment inherits the validated scaling math; pod `resources` stay the per-deployment sizing lever.

## What

- `worker-temporal` values + `docs/keda.md`: pairing rule documented (min ≥ 1 with `activity` preferred; min = 0 must include `workflow`); ScaledObject template guard on the bad combo.
- `worker-thunderbolt` (parent values): `maxConcurrency "8"` + derived calibration — `targetQueueSize "2"`, `queueTypes "activity"`, `minReplicas 1` (saas overrides to 4), 1800s stabilization, −1 pod/10min. Slots-hold prometheusTrigger stays per-deployment (namespace-qualified FQDN).
- `worker-temporal` default `maxConcurrency` **unchanged ("5")**; values comment warns that changing a worker's concurrency changes its scaling math. All non-thunderbolt workers: zero change (render-verified byte-identical).

## Validation

- Guard render-verified: fires on `min=0 + activity`, silent on valid pairings and defaults.
- Full-chart render diff vs main: only `worker-thunderbolt` deployment + ScaledObject change.
- Thunderbolt pure-default render: `TEMPORAL_MAX_CONCURRENCY=8`, min 1, target "2", `activity`, 1800s + policy. `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)