### PR TITLE
[ENG-4128]: Halve thunderbolt burst overshoot (targetQueueSize 2 → 4)

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.115
+version: 0.10.116
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/values.yaml
+++ b/charts/datafold/values.yaml
@@ -353,8 +353,11 @@ worker-thunderbolt:
     minReplicas: 1
     # Long-running LLM activities (up to 2h30m): a queued task means a long wait, so scale up
     # on any sustained queue. The old inherited default (targetQueueSize = maxConcurrency)
-    # implied a ~1.5h wait budget and never reacted (ENG-4128).
-    targetQueueSize: "2"
+    # implied a ~1.5h wait budget and never reacted (ENG-4128). "4" halves the burst
+    # overshoot observed at "2" (HPA converts queue length to pods through this value without
+    # knowing each pod absorbs maxConcurrency tasks; a 15-task burst produced 5 pods where
+    # 2 sufficed) while still reacting within one poll cycle.
+    targetQueueSize: "4"
     # Activity tasks are the only type that accumulates; workflow tasks drain in ms with a
     # live poller, and workflow-task orphan rows can never pollute the metric.
     queueTypes: "activity"


### PR DESCRIPTION
## Why

Live observation on the released config (testing, 15-task burst): replicas went 1 → **5** where **2** pods sufficed for throughput. Mechanism: the HPA converts queue length to pods through `targetQueueSize` without knowing each new pod absorbs `maxConcurrency` (8) queued tasks, so `"2"` over-provisions wide bursts ~2.5×.

`"4"` halves the overshoot while keeping the reaction inside one poll cycle (Jun-20 replay: backlog 11 → 3 pods, vs the pre-ENG-4128 config's zero reaction). Keeping options open per Filip — the composite total-demand formula (`(backlog+slots)/target` via scalingModifiers) is ticketed for exploration after prod observation.

## What

- `worker-thunderbolt.keda.targetQueueSize`: `"2"` → `"4"` (chart default; comment documents the observed trade). Testing soak already runs "4" via its CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)