### PR TITLE
[ENG-4128]: Ship per-pod identity on temporal_worker metrics

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.115
+version: 0.10.116
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/worker-temporal/templates/deployment.yaml
+++ b/charts/datafold/charts/worker-temporal/templates/deployment.yaml
@@ -44,13 +44,24 @@ spec:
         #    whole sample; include_labels keeps the task_queue KEY but not its
         #    values, so this value-level drop is still required. The real queues
         #    (io, highmem, storage, storagehigh, monitors, ...) stay queryable.
+        # 4. tags pod_name:%%kube_pod_name%% — re-injects the per-pod identity that
+        #    DD_CHECKS_TAG_CARDINALITY=low strips (see NOTE below). The SDK metrics
+        #    carry no pod identity of their own, so without this tag pods scheduled
+        #    on the SAME node submit identical tag sets and gauges collapse
+        #    last-write-wins (slots undercount, ENG-4128). The AD template variable
+        #    resolves at discovery; a per-instance `tag_cardinality` override is
+        #    silently ignored by the check (both validated live on the testing
+        #    cluster). Ingestion-side only: pod_name becomes QUERYABLE per metric
+        #    only where the Metrics-without-Limits allowlist admits it
+        #    (cloud-infra terraform/deployments/datadog/temporal_worker_tag_config.tf).
         #
         # NOTE: ignore_tags does NOT work here — it only filters Autodiscovery/Tagger
         # tags and the `tags` option, never labels scraped from the /metrics endpoint.
         # Kubernetes tagger tags are trimmed separately at the agent via
         # DD_CHECKS_TAG_CARDINALITY=low (DatadogAgent CR in the datadog chart,
         # configuration.checksTagCardinality), which drops the higher-cardinality
-        # orchestrator tags (pod_name, kube_replica_set, ...).
+        # orchestrator tags (pod_name, kube_replica_set, ...) — pod_name being
+        # re-added surgically via item 4 above.
         #
         # The host/cloud/node tag family (host, instance-id, availability-zone, aws_*,
         # region, instance-type, image*, zone, kube_node, ...) is NOT removed by this
@@ -66,6 +77,7 @@ spec:
                 "namespace": "temporal_worker",
                 "metrics": ["temporal_.*"],
                 "tag_by_endpoint": false,
+                "tags": ["pod_name:%%kube_pod_name%%"],
                 "include_labels": [
                   "task_queue",
                   "workflow_type",


### PR DESCRIPTION
## Why

The Temporal SDK metrics carry no pod identity, and the agent's `DD_CHECKS_TAG_CARDINALITY=low` strips `pod_name` from tagger enrichment — so worker pods co-scheduled on the same node submit identical tag sets and **gauges collapse last-write-wins** (the slots undercount noted in ENG-4140; same defect class our KEDA Prometheus avoided via its `pod` relabel).

## What

One line in the worker-temporal openmetrics annotation: `"tags": ["pod_name:%%kube_pod_name%%"]` (+ doc-block item 4 explaining it). Instance-wide by design — **per-metric queryability/cost is controlled in the Metrics-without-Limits allowlist** (companion cloud-infra PR adds `pod_name` to the slots/pollers gauges only). Ingested-but-unindexed tags on configured metrics are free; all 29 live `temporal_worker.*` metrics are covered by tag configs.

## Validation (live on the testing cluster)

- Negative result first: a per-instance `tag_cardinality: orchestrator` is **silently ignored** by the check (data flowed, `pod_name:N/A`) — the naive fix would have been a no-op.
- The AD template variable resolves at discovery (verified in `agent configcheck`: `pod_name:datafold-worker-io-...`) and flows end-to-end: verified queryable in DD via a throwaway `temporal_worker_podtest` metric namespace (no tag config → indexes everything), grouped `by {pod_name}` returning real per-pod series.
- `helm lint` clean; rendered annotation JSON parses.
- Footgun for reviewers: any FUTURE temporal_worker metric added without a tag configuration will index every ingested tag including pod_name — keeping temporal_worker_tag_config.tf covering all metrics stays load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)