### PR TITLE
fix: Bump operator to 1.2.15 for upgrade-attempt limiting

### DIFF
--- a/charts/datafold-crds/Chart.yaml
+++ b/charts/datafold-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-crds
 description: Helm chart package to deploy Datafold CRDs on kubernetes.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-crds/templates/dfappmanagers.yaml
+++ b/charts/datafold-crds/templates/dfappmanagers.yaml
@@ -28,3 +28,6 @@ spec:
                   type: string
                 datafoldVersionOverride:
                   type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/charts/datafold-manager/Chart.yaml
+++ b/charts/datafold-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold-manager
 description: Helm chart for Datafold Operator
 type: application
-version: 0.1.121
+version: 0.1.122
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold-manager/values.yaml
+++ b/charts/datafold-manager/values.yaml
@@ -18,7 +18,7 @@ operator:
   # Operator image configuration
   image:
     repository: us-docker.pkg.dev/datadiff-mm/datafold/datafold-operator
-    tag: "1.6.4"
+    tag: "1.6.5"
     pullPolicy: Always
 
   # Operator deployment configuration

--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.117
+version: 0.10.118
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/operator/Chart.yaml
+++ b/charts/datafold/charts/operator/Chart.yaml
@@ -3,4 +3,4 @@ name: operator
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0
-appVersion: "1.2.14"
+appVersion: "1.2.15"


### PR DESCRIPTION
Picks up the kopf-datafold fix that caps upgrade retries at 3 attempts per target version before holding for 24h. Also extends the DfAppManager CRD status schema to preserve the new upgradeAttempts / upgradeTargetVersion / lastUpgradeAttempt fields the operator now writes.

*Add a label `automerge` to automatically merge the PR after approval and passed checks.*

## Description
