### PR TITLE
[BOYSCOUT]: Grant dma/dfshell RBAC to scale the memgraph StatefulSet

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.119
+version: 0.10.120
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/memgraph/Chart.yaml
+++ b/charts/datafold/charts/memgraph/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: memgraph
 description: A Helm chart for Memgraph graph database
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"

--- a/charts/datafold/charts/memgraph/templates/scale-rbac.yaml
+++ b/charts/datafold/charts/memgraph/templates/scale-rbac.yaml
@@ -1,0 +1,61 @@
+{{- /*
+Per-org managed Memgraph graphs are provisioned at runtime by
+MemgraphsByOrg.create (datafold/knowledge_graph/registry.py): it patches this
+StatefulSet's replica count (_scale_statefulset) and polls the new pod for
+readiness (_wait_for_pod_healthy). That code runs inside the pods listed in
+.Values.scaleAccessServiceAccounts (dma, dfshell), whose service accounts would
+otherwise lack permission to read/scale StatefulSets, making
+`knowledge-graph create-graph` fail with a 403.
+*/ -}}
+{{- if .Values.scaleAccessServiceAccounts }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "memgraph.fullname" . }}-scale
+  labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  # _scale_statefulset patches the replica count via the scale subresource.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets/scale"]
+    verbs: ["get", "patch", "update"]
+  # _scale_statefulset reads the current replica count first.
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get"]
+  # _wait_for_pod_healthy polls the newly-created pod's readiness.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "memgraph.fullname" . }}-scale
+  labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "memgraph.fullname" . }}-scale
+subjects:
+  {{- range .Values.scaleAccessServiceAccounts }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+{{- end }}

--- a/charts/datafold/charts/memgraph/values.yaml
+++ b/charts/datafold/charts/memgraph/values.yaml
@@ -15,6 +15,13 @@ snapshotRetentionCount: 32
 # for off-cluster DR backups (e.g. [worker-temporal]). Empty = no RBAC rendered.
 backupAccessServiceAccounts: []
 
+# Service accounts granted RBAC to scale this StatefulSet. Runtime per-org DKG
+# graph provisioning patches the replica count from these pods
+# (knowledge_graph/registry.py). Empty list disables the Role/RoleBinding.
+scaleAccessServiceAccounts:
+  - dma
+  - dfshell
+
 storage:
   dataSize: 50Gi
   storageClass: ""


### PR DESCRIPTION
## Why

Per-org managed Memgraph graphs are provisioned at runtime by `MemgraphsByOrg.create` (`datafold/knowledge_graph/registry.py`): it patches the `datafold-memgraph` StatefulSet's replica count (`_scale_statefulset`) and polls the new pod for readiness (`_wait_for_pod_healthy`). That code runs inside the `dma` and `dfshell` pods, whose service accounts lack permission to read/scale StatefulSets — so `knowledge-graph create-graph` fails with:

```
statefulsets.apps "datafold-memgraph" is forbidden: User "system:serviceaccount:<ns>:dma"
cannot patch resource "statefulsets/scale" in API group "apps"
```

This was hit provisioning a new graph on saas (a fresh `datafold-memgraph-8`); the fix was applied live by hand and this PR codifies it.

## What

New `Role` + `RoleBinding` `datafold-memgraph-scale` in the **memgraph subchart**, granting exactly what the registry code calls:

| Resource | API group | Verbs | Used by |
|---|---|---|---|
| `statefulsets/scale` | apps | get, patch, update | `_scale_statefulset` |
| `statefulsets` | apps | get | `_scale_statefulset` (reads current replicas) |
| `pods` | "" | get | `_wait_for_pod_healthy` |

Subjects come from a new `scaleAccessServiceAccounts` value (default `[dma, dfshell]`; empty list disables the RBAC).

Placed in the memgraph subchart so it renders **only where memgraph is installed** — auto-covering saas, ecolab, and any future memgraph deployment with no per-cluster copies.

## Validation

- `helm lint charts/datafold` passes.
- `helm template` with memgraph enabled renders the Role + RoleBinding binding `dma`/`dfshell` in the release namespace.
- Gated off correctly when `memgraph.install=false` (subchart not rendered) and when `scaleAccessServiceAccounts` is empty.
- The equivalent RBAC is already live on saas (applied by hand), where it fixed `create-graph`.

## Rollout / cleanup

- Takes effect when the operator picks up chart `0.10.120`. The hand-applied live RBAC keeps `create-graph` working until then.
- Once this is live, delete the hand-created leftovers on saas (different names): `role/dma-memgraph-scale`, `rolebinding/dma-memgraph-scale`, `rolebinding/dfshell-memgraph-scale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
