### PR TITLE
[ENG-4100]: Grant worker-temporal RBAC to pull Memgraph snapshots

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.118
+version: 0.10.119
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/memgraph/templates/backup-rbac.yaml
+++ b/charts/datafold/charts/memgraph/templates/backup-rbac.yaml
@@ -1,0 +1,60 @@
+{{- /*
+Memgraph DR backups (datafold repo: docs/decisions/choose-memgraph-dr-architecture.md)
+pull each graph's newest snapshot file out of the Memgraph pod through the
+Kubernetes exec API (tar-over-exec, the kubectl-cp transport) and upload it to
+per-deployment object storage. The Temporal activity doing the pull runs in the
+pods listed in .Values.backupAccessServiceAccounts (worker-temporal), whose
+service account otherwise lacks permission to exec into pods.
+*/ -}}
+{{- if .Values.backupAccessServiceAccounts }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "memgraph.fullname" . }}-backup
+  labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  # The snapshot pull streams `tar cf -` from the Memgraph pod via exec.
+  # RBAC cannot scope exec by label or command, only by exact resourceNames —
+  # which cannot cover dynamically-scaled StatefulSet ordinals — so this is
+  # namespace-wide, the same blast radius the operator carries for ClickHouse
+  # backups.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  # Resolving the newest snapshot and the exec call itself read the pod.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "memgraph.fullname" . }}-backup
+  labels:
+    {{- include "memgraph.labels" . | nindent 4 }}
+    {{- with .Values.chartLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.chartAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "memgraph.fullname" . }}-backup
+subjects:
+  {{- range .Values.backupAccessServiceAccounts }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+{{- end }}

--- a/charts/datafold/charts/memgraph/values.yaml
+++ b/charts/datafold/charts/memgraph/values.yaml
@@ -11,6 +11,10 @@ fullnameOverride: ""
 terminationGracePeriodSeconds: 60
 snapshotRetentionCount: 32
 
+# Service accounts allowed to exec into Memgraph pods to pull snapshot files
+# for off-cluster DR backups (e.g. [worker-temporal]). Empty = no RBAC rendered.
+backupAccessServiceAccounts: []
+
 storage:
   dataSize: 50Gi
   storageClass: ""


### PR DESCRIPTION
## Summary

Memgraph DR backups (datafold repo: `docs/decisions/choose-memgraph-dr-architecture.md`, datafold/datafold#13758) stream each graph's newest snapshot file out of the Memgraph pod via the k8s exec API, from a Temporal activity running in the worker-io pod.

This renders an **opt-in** Role (`pods/exec create` + `pods get`) and RoleBinding for the service accounts listed in `memgraph.backupAccessServiceAccounts` (default `[]` = nothing rendered). Pattern mirrors `scale-rbac.yaml` from #374 and the ClickHouse-backup exec grant held by the operator. RBAC cannot scope exec by label/command, so the grant is namespace-wide — same blast radius the operator already carries; recorded in the ADR's security considerations.

Per-customer enablement goes through the operator CR (`memgraph.rawValues.backupAccessServiceAccounts: [worker]`) — wired in the companion cloud-infra PR. SaaS (hand-applied StatefulSets) gets the equivalent hand-applied Role/RoleBinding, seed kept in cloud-infra.

## Validation

`helm template charts/datafold --set memgraph.install=true --set global.cloudProvider=aws --set memgraph.backupAccessServiceAccounts='{worker-temporal}' --show-only charts/memgraph/templates/backup-rbac.yaml` renders the Role + RoleBinding; without the value, nothing is rendered. Chart version bumped for ct lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)