### PR TITLE
Parameterize the memgraph init container image

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.121
+version: 0.10.122
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/memgraph/Chart.yaml
+++ b/charts/datafold/charts/memgraph/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: memgraph
 description: A Helm chart for Memgraph graph database
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "latest"

--- a/charts/datafold/charts/memgraph/templates/statefulset.yaml
+++ b/charts/datafold/charts/memgraph/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: init-chown
-          image: busybox:latest
+          image: {{ .Values.initImage }}
           command: ["sh", "-c", "chown -R 101:103 /var/lib/memgraph"]
           securityContext:
             {{- toYaml .Values.initSecurityContext | nindent 12 }}

--- a/charts/datafold/charts/memgraph/values.yaml
+++ b/charts/datafold/charts/memgraph/values.yaml
@@ -5,6 +5,9 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+# Image for the init-chown init container.
+initImage: busybox:latest
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Changes

- Add an `initImage` value to the memgraph subchart (default: `busybox:latest`).
- Use it for the `init-chown` init container in `statefulset.yaml` instead of a hardcoded image reference.
- Bump chart versions: memgraph `0.1.1` → `0.1.2`, datafold `0.10.121` → `0.10.122`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)