### PR TITLE
[BOYSCOUT]: Make server startup probe failureThreshold configurable

### DIFF
--- a/charts/datafold/Chart.yaml
+++ b/charts/datafold/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datafold
 description: Helm chart package to deploy Datafold on kubernetes.
 type: application
-version: 0.10.124
+version: 0.10.125
 appVersion: "1.0.0"
 icon: https://www.datafold.com/logo.png
 

--- a/charts/datafold/charts/server/Chart.yaml
+++ b/charts/datafold/charts/server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: server
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/charts/datafold/charts/server/templates/deployment.yaml
+++ b/charts/datafold/charts/server/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
                   value: {{ .Values.global.statusCheckToken }}
                 {{- end }}
             periodSeconds: 10
-            failureThreshold: 6
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             timeoutSeconds: 5
           livenessProbe:
             failureThreshold: 10

--- a/charts/datafold/charts/server/values.yaml
+++ b/charts/datafold/charts/server/values.yaml
@@ -19,6 +19,9 @@ nameOverride: ""
 fullnameOverride: ""
 terminationGracePeriodSeconds: "120"
 
+startupProbe:
+  failureThreshold: 6
+
 command: "server"
 
 # Optional: set to a number of minutes to set DATAFOLD_USER_ACTIVITY_INTERVAL_MINUTES


### PR DESCRIPTION
Add a `server.startupProbe.failureThreshold` value (default `6`) and use it in the
deployment template instead of a hardcoded literal.

No behaviour change at the default. Rendered both paths:

- default -> `failureThreshold: 6`
- `--set server.startupProbe.failureThreshold=30` -> `failureThreshold: 30`

Chart versions bumped: `datafold` 0.10.124 -> 0.10.125, `server` 0.1.0 -> 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)